### PR TITLE
MockMvc의 ResponseBody에 대한 테스트 검증 객체 추가

### DIFF
--- a/src/test/java/com/wnis/linkyway/utils/ResponseBodyMatchers.java
+++ b/src/test/java/com/wnis/linkyway/utils/ResponseBodyMatchers.java
@@ -1,0 +1,74 @@
+package com.wnis.linkyway.utils;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.exc.UnrecognizedPropertyException;
+import org.springframework.test.web.servlet.ResultMatcher;
+
+import java.lang.reflect.Field;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ *
+ * ResponseBodyMatcher is very useful when using mvcMock.
+ *
+ * <p>This can be used to verify the contents of the body for the response when testing the controller.</p>
+ *<p>example</p>
+ * <pre> {@code
+ *                 MvcResult mvcResult = mockMvc.perform(post("/api/tags")
+ *                         .contentType("application/json")
+ *                         .content(objectMapper.writeValueAsString(tagRequest)))
+ *                         .andExpect(status().is(400))
+ *                         .andExpect(responseBody() // create ResponseBodyMatcher
+ *                                 .containsPropertiesAsJson(ErrorResponse.class)) // method
+ *                         .andReturn();
+ *
+ * }
+ *
+ * </pre>
+ *
+ * @author Hyeongyu
+ * @version 1.0.0
+ */
+public class ResponseBodyMatchers {
+    private ObjectMapper objectMapper = new ObjectMapper();
+    /**
+     * <p>Validate that the field name and value of the ResponseBody object are the same as expected</p>
+     * <p>you do not need to create Object for test. just use *.class</p>
+     * @param expectedObject Object created for test
+     * @param targetClass Expected class structure (*.class)
+     */
+    public <T>ResultMatcher containsObjectAsJson(
+            Object expectedObject,
+            Class<T> targetClass) {
+        return mvcResult -> {
+            String json =mvcResult.getResponse().getContentAsString();
+            T actualObject = objectMapper.readValue(json, targetClass);
+            assertThat(actualObject).extracting("errors").isEqualToComparingFieldByField(expectedObject);
+        };
+    }
+
+    /**
+     * <p>Verify that the field name of the ResponseBody object matches the field name of the expected class.</p>
+     * @param targetClass expected class structure (*.class)
+     * @throws UnrecognizedPropertyException If the format of the target class and the response object does not match,
+     * an exception is generated.
+     */
+    public <T>ResultMatcher containsPropertiesAsJson(
+            Class<T> targetClass) {
+        return mvcResult -> {
+            String json =mvcResult.getResponse().getContentAsString();
+            T actualObject = objectMapper.readValue(json, targetClass);
+            for (Field field : targetClass.getFields()) {
+                assertThat(actualObject).hasFieldOrProperty(field.getName());
+            }
+        };
+    }
+
+    public static ResponseBodyMatchers responseBody() {
+        return new ResponseBodyMatchers();
+    }
+
+
+}
+

--- a/src/test/java/com/wnis/linkyway/utils/ResponseBodyMatchers.java
+++ b/src/test/java/com/wnis/linkyway/utils/ResponseBodyMatchers.java
@@ -71,6 +71,5 @@ public class ResponseBodyMatchers {
         return new ResponseBodyMatchers();
     }
 
-
 }
 

--- a/src/test/java/com/wnis/linkyway/utils/ResponseBodyMatchers.java
+++ b/src/test/java/com/wnis/linkyway/utils/ResponseBodyMatchers.java
@@ -57,7 +57,7 @@ public class ResponseBodyMatchers {
     public <T>ResultMatcher containsPropertiesAsJson(
             Class<T> targetClass) {
         return mvcResult -> {
-            String json =mvcResult.getResponse().getContentAsString();
+            String json = mvcResult.getResponse().getContentAsString();
             T actualObject = objectMapper.readValue(json, targetClass);
             for (Field field : targetClass.getFields()) {
                 assertThat(actualObject).hasFieldOrProperty(field.getName());

--- a/src/test/java/com/wnis/linkyway/utils/ResponseBodyMatchers.java
+++ b/src/test/java/com/wnis/linkyway/utils/ResponseBodyMatchers.java
@@ -44,7 +44,9 @@ public class ResponseBodyMatchers {
         return mvcResult -> {
             String json =mvcResult.getResponse().getContentAsString();
             T actualObject = objectMapper.readValue(json, targetClass);
-            assertThat(actualObject).extracting("errors").isEqualToComparingFieldByField(expectedObject);
+        assertThat(actualObject)
+                .usingRecursiveComparison()
+                .isEqualTo(expectedObject);
         };
     }
 


### PR DESCRIPTION

[사용예시]
![image](https://user-images.githubusercontent.com/39326175/168454352-0c82710f-7664-42a6-9a20-032d05b5cd0f.png)

- body에 대한 테스트는 따로 작성해야하기 때문에 test의 가독성과 생산성을 올리고자 만듬
- 팀원들이 사용하기 편하게 javadocs로 문서화 해놓음.