### PR TITLE
Jwt Access Token과 기능 추가

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -20,7 +20,7 @@ repositories {
 
 dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
-    implementation 'org.springframework.boot:spring-boot-starter-data-rest'
+//    implementation 'org.springframework.boot:spring-boot-starter-data-rest'
     implementation 'org.springframework.boot:spring-boot-starter-validation'
     implementation 'org.springframework.boot:spring-boot-starter-web'
     compileOnly 'org.projectlombok:lombok'
@@ -32,6 +32,19 @@ dependencies {
     // swagger
     implementation 'io.springfox:springfox-boot-starter:3.0.0'
     implementation 'io.springfox:springfox-swagger-ui:3.0.0'
+
+    // security
+    implementation group: 'org.springframework.boot', name: 'spring-boot-starter-security', version: '2.6.7'
+    testImplementation group: 'org.springframework.security', name: 'spring-security-test', version: '5.6.3'
+
+    // jwt
+    implementation group: 'io.jsonwebtoken', name: 'jjwt-api', version: '0.11.2'
+    runtimeOnly group: 'io.jsonwebtoken', name: 'jjwt-impl', version: '0.11.2'
+    runtimeOnly group: 'io.jsonwebtoken', name: 'jjwt-jackson', version: '0.11.2'
+
+    // @Configuration Properties 활용하기 위한 의존성
+    implementation group: 'org.springframework.boot', name: 'spring-boot-configuration-processor', version: '2.6.7'
+
 }
 
 tasks.named('test') {

--- a/src/main/java/com/wnis/linkyway/config/PropertiesConfiguration.java
+++ b/src/main/java/com/wnis/linkyway/config/PropertiesConfiguration.java
@@ -1,0 +1,11 @@
+package com.wnis.linkyway.config;
+
+import com.wnis.linkyway.security.jwt.JwtProperties;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+@EnableConfigurationProperties(value = {JwtProperties.class})
+public class PropertiesConfiguration {
+
+}

--- a/src/main/java/com/wnis/linkyway/config/SecurityConfiguration.java
+++ b/src/main/java/com/wnis/linkyway/config/SecurityConfiguration.java
@@ -1,0 +1,40 @@
+package com.wnis.linkyway.config;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Bean;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.config.annotation.web.configuration.WebSecurityConfigurerAdapter;
+import org.springframework.security.config.http.SessionCreationPolicy;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.security.crypto.password.PasswordEncoder;
+
+@EnableWebSecurity
+@RequiredArgsConstructor
+public class SecurityConfiguration extends WebSecurityConfigurerAdapter {
+
+    @Override
+    protected void configure(HttpSecurity http) throws Exception {
+
+        http
+                .csrf().disable()
+                .logout().disable()
+                .httpBasic().disable()
+                .formLogin().disable()
+                .sessionManagement()
+                .sessionCreationPolicy(SessionCreationPolicy.STATELESS)
+                .and()
+                .authorizeRequests()
+                .antMatchers("/**")
+                .permitAll()
+                .anyRequest()
+                .authenticated();
+
+    }
+
+    @Bean
+    public PasswordEncoder passwordEncoder() {
+        return new BCryptPasswordEncoder();
+    }
+
+}

--- a/src/main/java/com/wnis/linkyway/security/jwt/JwtPrincipal.java
+++ b/src/main/java/com/wnis/linkyway/security/jwt/JwtPrincipal.java
@@ -1,0 +1,16 @@
+package com.wnis.linkyway.security.jwt;
+
+import lombok.Getter;
+
+@Getter
+public class JwtPrincipal {
+
+    private final Long id;
+    private final String email;
+
+    public JwtPrincipal(Long id, String email) {
+        this.id = id;
+        this.email = email;
+    }
+
+}

--- a/src/main/java/com/wnis/linkyway/security/jwt/JwtProperties.java
+++ b/src/main/java/com/wnis/linkyway/security/jwt/JwtProperties.java
@@ -1,0 +1,24 @@
+package com.wnis.linkyway.security.jwt;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.boot.context.properties.ConstructorBinding;
+
+@Getter
+@RequiredArgsConstructor
+@ConstructorBinding
+@ConfigurationProperties(prefix = "jwt")
+public class JwtProperties {
+
+    private final String secretKey;
+    private final AccessToken accessToken;
+
+    @Getter
+    @RequiredArgsConstructor
+    public static final class AccessToken {
+        private final String name;
+        private final Long validTime;
+    }
+
+}

--- a/src/main/java/com/wnis/linkyway/security/jwt/JwtProvider.java
+++ b/src/main/java/com/wnis/linkyway/security/jwt/JwtProvider.java
@@ -1,0 +1,63 @@
+package com.wnis.linkyway.security.jwt;
+
+import io.jsonwebtoken.*;
+import io.jsonwebtoken.security.Keys;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.security.core.Authentication;
+import org.springframework.stereotype.Component;
+
+import java.nio.charset.StandardCharsets;
+import java.security.Key;
+import java.util.Date;
+
+
+@Slf4j
+@Component
+public class JwtProvider {
+
+    private final JwtProperties jwtProperties;
+    private final Key key;
+    private static final String CLAIM_NAME = "cName";
+
+    public JwtProvider(JwtProperties jwtProperties) {
+        this.jwtProperties = jwtProperties;
+        this.key = Keys.hmacShaKeyFor(jwtProperties.getSecretKey().getBytes(StandardCharsets.UTF_8));
+    }
+
+    public <T extends Authentication> String createAccessToken(T authentication) {
+        JwtPrincipal jwtPrincipal = (JwtPrincipal) authentication.getPrincipal();
+
+        return Jwts.builder()
+                .setSubject(jwtPrincipal.getId().toString())
+                .claim(CLAIM_NAME, jwtPrincipal.getEmail())
+                .setIssuedAt(new Date(System.currentTimeMillis()))
+                .setExpiration(
+                        new Date(System.currentTimeMillis() +
+                                jwtProperties.getAccessToken().getValidTime() * 1000 * 60)
+                )
+                .signWith(key, SignatureAlgorithm.HS512)
+                .compact();
+    }
+
+    public boolean validateToken(String token) {
+        try {
+            parseClaims(token);
+            return true;
+        } catch (io.jsonwebtoken.security.SecurityException | MalformedJwtException |
+                IllegalArgumentException | UnsupportedJwtException e) {
+            log.info("잘못된 토큰입니다: '{}'", token);
+        } catch (ExpiredJwtException e) {
+            log.info("만료된 토큰입니다: '{}'", token);
+        }
+        return false;
+    }
+
+    private Claims parseClaims(String accessToken) {
+        return Jwts.parserBuilder()
+                .setSigningKey(key).build()
+                .parseClaimsJws(accessToken)
+                .getBody();
+    }
+
+}
+

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -8,3 +8,6 @@ spring:
     database-platform: org.hibernate.dialect.H2Dialect
     properties.hibernate.hbm2ddl.auto: create-drop
     showSql: true
+  config:
+    import:
+      - classpath:jwt.yml

--- a/src/main/resources/jwt.yml
+++ b/src/main/resources/jwt.yml
@@ -1,0 +1,5 @@
+jwt:
+  secret-key: linkywayteamisgoodlinkywayteamisgoodlinkywayteamisgoodlinkywayteamisgoodlinkywayteamisgoodlinkywayteamisgoodlinkywayteamisgood
+  access-token:
+    name: access_token
+    valid-time: 6

--- a/src/test/java/com/wnis/linkyway/security/jwt/JwtPropertiesTest.java
+++ b/src/test/java/com/wnis/linkyway/security/jwt/JwtPropertiesTest.java
@@ -1,0 +1,32 @@
+package com.wnis.linkyway.security.jwt;
+
+import com.wnis.linkyway.config.PropertiesConfiguration;
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+
+import static org.assertj.core.api.Assertions.*;
+
+@SpringBootTest(classes = {PropertiesConfiguration.class})
+class JwtPropertiesTest {
+
+    @Autowired
+    private JwtProperties jwtProperties;
+
+    private final JwtProperties.AccessToken accessToken =
+            new JwtProperties.AccessToken("access_token", 6L);
+
+    @Test
+    @DisplayName("Jwt 설정 정보 로드 테스트")
+    void getJwtPropertiesTest() {
+        assertThat(jwtProperties).isNotNull()
+                .isInstanceOfSatisfying(JwtProperties.class, jwt -> {
+                    assertThat(jwt.getSecretKey()).isNotNull();
+                    assertThat(jwt.getAccessToken()).isNotNull()
+                            .usingRecursiveComparison().isEqualTo(accessToken);
+                });
+    }
+
+}

--- a/src/test/java/com/wnis/linkyway/security/jwt/JwtProviderTest.java
+++ b/src/test/java/com/wnis/linkyway/security/jwt/JwtProviderTest.java
@@ -1,0 +1,86 @@
+package com.wnis.linkyway.security.jwt;
+
+import com.wnis.linkyway.config.PropertiesConfiguration;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.security.authentication.AbstractAuthenticationToken;
+
+import java.util.stream.Stream;
+
+import static org.assertj.core.api.Assertions.*;
+
+@SpringBootTest(classes = {PropertiesConfiguration.class, JwtProvider.class})
+class JwtProviderTest {
+
+    @Autowired
+    private JwtProvider jwtProvider;
+
+    private static final String EXPIRED_TOKEN = "eyJhbGciOiJIUzUxMiJ9.eyJzdWIiOiIxIiwiY05hbWUiOiJlaGQwMzA5QG5hdmVyLmNvbSIsImlhdCI6MTY1Mjg1OTgxMCwiZXhwIjoxNjUyODU5ODEwfQ.GkZU7vAGCBhOjf3lP-EmF9C9Y6A2gcjLcvOWjUKzl_d7bMI-z4hyPznYlTVFOKuO8cSqyUBfjv2nJ-cVY_OLJQ";
+    private static final String WRONG_TOKEN = "eyJhbGciOiJIUzUxMiJ9.abczdWIiOiIxIiwiY05hbWUiOiJlaGQwMzA5QG5hdmVyLmNvbSIsImlhdCI6MTY1Mjg1OTgxMCwiZXhwIjoxNjUyODU5ODEwfQ.GkZU7vAGCBhOjf3lP-EmF9C9Y6A2gcjLcvOWjUKzl_d7bMI-z4hyPznYlTVFOKuO8cSqyUBfjv2nJ-cVY_OLJQ";
+
+    private static final Long id = 1L;
+    private static final String email = "ehd0309@naver.com";
+    private final SampleAuthenticationImpl authentication =
+            new SampleAuthenticationImpl(new JwtPrincipal(id, email));
+
+    @Test
+    @DisplayName("액세스 토큰 생성 테스트")
+    void createAccessTokenTest() {
+        assertThat(jwtProvider.createAccessToken(authentication))
+                .isNotNull();
+    }
+
+    @TestInstance(TestInstance.Lifecycle.PER_CLASS)
+    @Nested
+    @DisplayName("토큰 유효성 검사 테스트")
+    class ValidTokenTest {
+        Stream<String> wrongTokens() {
+            return Stream.of("", " ", null, EXPIRED_TOKEN, WRONG_TOKEN);
+        }
+
+        @ParameterizedTest
+        @MethodSource("wrongTokens")
+        @DisplayName("잘못된 토큰 입력에 대해 false를 리턴한다.")
+        void shouldReturnFalseWithWrongTokens(String token) {
+            assertThat(jwtProvider.validateToken(token))
+                    .isFalse();
+        }
+
+        @Test
+        @DisplayName("정상적인 토큰에 대해 true를 리턴한다.")
+        void shouldReturnTrueWithNormalToken() {
+            String normalAccessToken = jwtProvider.createAccessToken(authentication);
+            assertThat(jwtProvider.validateToken(normalAccessToken))
+                    .isTrue();
+        }
+
+    }
+
+    static class SampleAuthenticationImpl extends AbstractAuthenticationToken {
+
+        private final Object principal;
+
+        public SampleAuthenticationImpl(Object principal) {
+            super(null);
+            this.principal = principal;
+        }
+
+        @Override
+        public Object getCredentials() {
+            return null;
+        }
+
+        @Override
+        public Object getPrincipal() {
+            return this.principal;
+        }
+
+    }
+
+}


### PR DESCRIPTION

**추가한 사항**

- [x] `JWT AccessToken` 토큰 설정 파일을 통해 서비스에서 사용하도록 구성

- [x] `JWT AccessToken`과 관련된 기능을 수행하는 `JwtProvider` 클래스 구현
  - 액세스 토큰 생성
  - 액세스 토큰 검증


 
<br>


**TODO**

- 커스텀 인증객체 구현 후 액세스 토큰으로부터 인증 객체를 얻을 수 있어야 한다.

