### PR TITLE
Feat/#24/tag controller

### DIFF
--- a/src/main/java/com/wnis/linkyway/controller/TagController.java
+++ b/src/main/java/com/wnis/linkyway/controller/TagController.java
@@ -1,0 +1,63 @@
+package com.wnis.linkyway.controller;
+
+import com.wnis.linkyway.dto.Response;
+import com.wnis.linkyway.dto.tag.TagRequest;
+import com.wnis.linkyway.security.annotation.Authenticated;
+import com.wnis.linkyway.security.annotation.CurrentMember;
+import com.wnis.linkyway.service.tag.TagService;
+import com.wnis.linkyway.validation.ValidationSequence;
+import io.swagger.annotations.ApiOperation;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.*;
+import springfox.documentation.annotations.ApiIgnore;
+
+@RequiredArgsConstructor
+@RestController
+@RequestMapping("/api")
+public class TagController {
+    
+    private final TagService tagService;
+    
+    @GetMapping("/tags/table")
+    @ApiOperation(value = "태그 조회", notes = "해당 회원이 가지고 있는 태그 리스트를 조회한다.")
+    @Authenticated
+    public ResponseEntity<Response> searchTags(@ApiIgnore @CurrentMember Long memberId) {
+        Response response = tagService.searchTags(memberId);
+        return ResponseEntity.ok(response);
+    }
+    
+    @PostMapping("/tags")
+    @ApiOperation(value = "태그 추가", notes = "해당 회원이 가지고 있는 태그를 추가한다.")
+    @Authenticated
+    public ResponseEntity<Response> addTag(
+            @ApiIgnore @CurrentMember Long memberId,
+            @Validated(ValidationSequence.class) @RequestBody TagRequest tagRequest) {
+        
+        Response response = tagService.addTag(tagRequest, memberId);
+        return ResponseEntity.ok(response);
+    }
+    
+    @PutMapping("/tags/{tagId}")
+    @ApiOperation(value = "태그 수정", notes = "해당 회원이 가지고 있는 태그를 수정한다.")
+    @Authenticated
+    public ResponseEntity<Response> setTag(
+            @ApiIgnore @CurrentMember Long memberId,
+            @PathVariable(value = "tagId") Long tagId,
+            @RequestBody TagRequest tagRequest) {
+        
+        Response response = tagService.setTag(tagRequest, tagId);
+        return ResponseEntity.ok(response);
+    }
+    
+    @DeleteMapping("/tags/{tagId}")
+    @ApiOperation(value = "태그 삭제", notes = "해당 회원이 가지오 있는 태그를 삭제한다.")
+    @Authenticated
+    public ResponseEntity<Response> deleteTag(
+            @PathVariable(value = "tagId") Long tagId) {
+        
+        Response response = tagService.deleteTag(tagId);
+        return ResponseEntity.ok(response);
+    }
+}

--- a/src/main/java/com/wnis/linkyway/dto/tag/TagRequest.java
+++ b/src/main/java/com/wnis/linkyway/dto/tag/TagRequest.java
@@ -1,26 +1,25 @@
 package com.wnis.linkyway.dto.tag;
 
 
-import com.wnis.linkyway.validation.ValidationGroup;
 import lombok.*;
 
 import javax.validation.constraints.NotBlank;
 import javax.validation.constraints.Pattern;
 import javax.validation.constraints.Size;
 
-import static com.wnis.linkyway.validation.ValidationGroup.*;
+import static com.wnis.linkyway.validation.ValidationGroup.NotBlankGroup;
+import static com.wnis.linkyway.validation.ValidationGroup.PatternCheckGroup;
 
 @Getter
 @NoArgsConstructor
 @AllArgsConstructor(access = AccessLevel.PRIVATE)
 @Builder
 public class TagRequest {
-
-    @NotBlank(message = "tagName을 입력해주세요", groups = NotBlankGroup.class)
-    @Size(max = 10, message = "10자 이하로 작성해주세요")
-    private String tagName;
-
+    
     @NotBlank(message = "소셜 공유 여부를 입력해주세요", groups = NotBlankGroup.class)
     @Pattern(regexp = "(true|false)", groups = PatternCheckGroup.class)
     String shareable;
+    @NotBlank(message = "tagName을 입력해주세요", groups = NotBlankGroup.class)
+    @Size(max = 10, message = "10자 이하로 작성해주세요")
+    private String tagName;
 }

--- a/src/main/java/com/wnis/linkyway/dto/tag/TagResponse.java
+++ b/src/main/java/com/wnis/linkyway/dto/tag/TagResponse.java
@@ -2,21 +2,20 @@ package com.wnis.linkyway.dto.tag;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.wnis.linkyway.entity.Tag;
-import lombok.*;
-
-import java.util.ArrayList;
-import java.util.List;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
 
 @Getter
 @NoArgsConstructor
 @JsonInclude(JsonInclude.Include.NON_EMPTY)
 public class TagResponse {
-
+    
     private Long tagId;
     private String tagName;
     private Boolean shareable;
     private Integer views;
-
+    
     @Builder
     private TagResponse(Long tagId, String tagName,
                         Boolean shareable, Integer views) {
@@ -25,7 +24,7 @@ public class TagResponse {
         this.shareable = shareable;
         this.views = views;
     }
-
+    
     public TagResponse(Tag tag) {
         this.tagId = tag.getId();
         this.tagName = tag.getName();

--- a/src/main/java/com/wnis/linkyway/repository/TagRepository.java
+++ b/src/main/java/com/wnis/linkyway/repository/TagRepository.java
@@ -1,14 +1,32 @@
 package com.wnis.linkyway.repository;
 
 
+import com.wnis.linkyway.dto.tag.TagResponse;
 import com.wnis.linkyway.entity.Tag;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 import java.util.List;
 
 public interface TagRepository extends JpaRepository<Tag, Long> {
     @Query("select t from Tag t join fetch t.member")
-    List<Tag> findAllIncludesTag();
-
+    public List<Tag> findAllIncludesTag();
+    
+    @Query("select new com.wnis.linkyway.dto.tag.TagResponse(t) " +
+            "from Tag t join t.member where t.member.id = :memberId")
+    public List<TagResponse> findAllTagList(@Param("memberId") Long memberId);
+    
+    @Query("select t from Tag t join fetch t.member " +
+            "where t.name = :name and t.member.id = :id")
+    public Tag findByTagNameAndMemberId(@Param(value = "name") String name,
+                                        @Param(value = "id") Long id);
+    
+    @Modifying
+    @Query(value = "insert into tag (name, shareable, views, member_member_id)" +
+            "values (:name, :shareable, 0, :member_id)", nativeQuery = true)
+    public void addTag(@Param("name") String name,
+                       @Param("shareable") boolean shareable,
+                       @Param("member_id") Long memberId);
 }

--- a/src/main/java/com/wnis/linkyway/service/tag/TagService.java
+++ b/src/main/java/com/wnis/linkyway/service/tag/TagService.java
@@ -1,0 +1,16 @@
+package com.wnis.linkyway.service.tag;
+
+import com.wnis.linkyway.dto.Response;
+import com.wnis.linkyway.dto.tag.TagRequest;
+
+public interface TagService {
+    
+    Response searchTags(Long memberId);
+    
+    Response addTag(TagRequest tagRequest, Long memberId);
+    
+    Response setTag(TagRequest tagRequest, Long tagId);
+    
+    Response deleteTag(Long tagId);
+    
+}

--- a/src/main/java/com/wnis/linkyway/service/tag/TagServiceImpl.java
+++ b/src/main/java/com/wnis/linkyway/service/tag/TagServiceImpl.java
@@ -1,0 +1,85 @@
+package com.wnis.linkyway.service.tag;
+
+import com.wnis.linkyway.dto.Response;
+import com.wnis.linkyway.dto.tag.TagRequest;
+import com.wnis.linkyway.dto.tag.TagResponse;
+import com.wnis.linkyway.entity.Tag;
+import com.wnis.linkyway.exception.common.ResourceConflictException;
+import com.wnis.linkyway.repository.MemberRepository;
+import com.wnis.linkyway.repository.TagRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+
+import javax.transaction.Transactional;
+import java.util.List;
+
+@Service("tagService")
+@Transactional
+@RequiredArgsConstructor
+@Slf4j
+public class TagServiceImpl implements TagService {
+    
+    private final TagRepository tagRepository;
+    
+    private final MemberRepository memberRepository;
+    
+    
+    @Override
+    public Response searchTags(Long memberId) {
+        List<TagResponse> tagList = tagRepository.findAllTagList(memberId);
+        return Response.<List<TagResponse>>builder()
+                .code(200)
+                .message("성공적으로 태그를 조회했습니다.")
+                .data(tagList)
+                .build();
+    }
+    
+    @Override
+    public Response addTag(TagRequest tagRequest, Long memberId) {
+        Tag tag = tagRepository.findByTagNameAndMemberId(tagRequest.getTagName(), memberId);
+        if (tag != null) {
+            throw new ResourceConflictException("입력 값이 이미 존재합니다.");
+        }
+        tagRepository.addTag(tagRequest.getTagName(), Boolean.parseBoolean(tagRequest.getShareable()), memberId);
+        Tag t = tagRepository.findByTagNameAndMemberId(tagRequest.getTagName(), memberId);
+        TagResponse tagResponse = TagResponse.builder()
+                .tagId(t.getId())
+                .build();
+        
+        return Response.<TagResponse>builder()
+                .code(200)
+                .message(String.format("%s 태그가 성공적으로 생성되었습니다.", t.getName()))
+                .data(tagResponse)
+                .build();
+        
+    }
+    
+    @Override
+    public Response setTag(TagRequest tagRequest, Long tagId) {
+        Tag tag = tagRepository.findById(tagId).orElse(null);
+        if (tag == null) {
+            throw new ResourceConflictException("태그가 존재하지 않아 수정 할 수 없습니다.");
+        }
+        tag.updateName(tagRequest.getTagName()).updateShareable(Boolean.parseBoolean(tagRequest.getShareable()));
+        Tag t = tagRepository.save(tag);
+        return Response.builder()
+                .code(200)
+                .message(String.format("%s 태그가 성공적으로 수정되었습니다.", t.getName()))
+                .build();
+    }
+    
+    @Override
+    public Response deleteTag(Long tagId) {
+        Tag tag = tagRepository.findById(tagId).orElse(null);
+        if (tag == null) {
+            throw new ResourceConflictException("태그가 존재하지 않아 삭제 할 수 없습니다.");
+        }
+        tagRepository.deleteById(tagId);
+        return Response.builder()
+                .code(200)
+                .message("성공적으로 삭제되었습니다.")
+                .build();
+    }
+    
+}

--- a/src/main/resources/sqltest/initialize-test.sql
+++ b/src/main/resources/sqltest/initialize-test.sql
@@ -1,0 +1,4 @@
+ALTER TABLE member auto_increment = 1;
+ALTER TABLE tag auto_increment = 1;
+ALTER TABLE card auto_increment = 1;
+ALTER TABLE folder auto_increment = 1;

--- a/src/test/java/com/wnis/linkyway/controller/tag/TagControllerIntegrationTest.java
+++ b/src/test/java/com/wnis/linkyway/controller/tag/TagControllerIntegrationTest.java
@@ -1,0 +1,223 @@
+package com.wnis.linkyway.controller.tag;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.wnis.linkyway.dto.Response;
+import com.wnis.linkyway.dto.tag.TagRequest;
+import com.wnis.linkyway.entity.Member;
+import com.wnis.linkyway.entity.Tag;
+import com.wnis.linkyway.repository.MemberRepository;
+import com.wnis.linkyway.repository.TagRepository;
+import com.wnis.linkyway.security.testutils.WithMockMember;
+import com.wnis.linkyway.service.tag.TagService;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.test.context.jdbc.Sql;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.MvcResult;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+import org.springframework.web.context.WebApplicationContext;
+import org.springframework.web.filter.CharacterEncodingFilter;
+
+import javax.transaction.Transactional;
+import java.util.Arrays;
+
+import static org.springframework.security.test.web.servlet.setup.SecurityMockMvcConfigurers.springSecurity;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@SpringBootTest
+@AutoConfigureMockMvc
+@Transactional
+@Sql("/sqltest/initialize-test.sql")
+public class TagControllerIntegrationTest {
+    
+    private final Logger logger = LoggerFactory.getLogger(TagControllerIntegrationTest.class);
+    @Autowired
+    WebApplicationContext ctx;
+    @Autowired
+    MemberRepository memberRepository;
+    @Autowired
+    TagRepository tagRepository;
+    @Autowired
+    TagService tagService;
+    @Autowired
+    ObjectMapper objectMapper;
+    @Autowired
+    MockMvc mockMvc;
+    
+    @BeforeEach
+    void setup() {
+        
+        //MockMvc 설정
+        mockMvc = MockMvcBuilders.webAppContextSetup(ctx)
+                .apply(springSecurity())
+                .addFilters(new CharacterEncodingFilter("UTF-8", true))  // 필터 추가
+                .alwaysDo(print())
+                .build();
+        
+        Member member = Member.builder()
+                .email("marrin1101@naver.com")
+                .nickname("Hyeon")
+                .password("A1!a1234")
+                .build();
+        
+        Tag tag1 = Tag.builder()
+                .name("Spring")
+                .shareable(true)
+                .views(0)
+                .build();
+        
+        Tag tag2 = Tag.builder()
+                .name("food1")
+                .shareable(false)
+                .views(10)
+                .build();
+        
+        member.addTag(tag1).addTag(tag2);
+        tagRepository.saveAll(Arrays.asList(tag1, tag2));
+        memberRepository.save(member);
+    }
+    
+    @Nested
+    @DisplayName("태그 조회")
+    class SearchTagsTest {
+        
+        @Test
+        @DisplayName("태그 조회 Response")
+        @WithMockMember(id = 1, email = "marrin1101@naver.com")
+        void responseTest() throws Exception {
+            Response response = tagService.searchTags(1L);
+            ResponseEntity<Response> expected = ResponseEntity.ok(response);
+            
+            MvcResult mvcResult = mockMvc.perform(get("/api/tags/table"))
+                    .andExpect(status().is(200))
+                    .andReturn();
+            
+            String s = mvcResult.getResponse().getContentAsString();
+            logger.info(s);
+            
+        }
+    }
+    
+    @Nested
+    @DisplayName("태그 추가")
+    class AddTagTest {
+        
+        @Test
+        @DisplayName("태그 추가 Response")
+        @WithMockMember(id = 1, email = "marrin1101@naver.com")
+        void ResponseTest() throws Exception {
+            TagRequest tagRequest = TagRequest.builder()
+                    .tagName("hello")
+                    .shareable("true")
+                    .build();
+            MvcResult mvcResult = mockMvc.perform(post("/api/tags")
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content(objectMapper.writeValueAsString(tagRequest)))
+                    .andExpect(status().isOk())
+                    .andReturn();
+            String res = mvcResult.getResponse().getContentAsString();
+            logger.info(res);
+            
+        }
+        
+        @Test
+        @DisplayName("중복시 핸들러 Response")
+        @WithMockMember(id = 1, email = "marrin1101@naver.com")
+        void ResponseExceptionTest() throws Exception {
+            TagRequest tagRequest = TagRequest.builder()
+                    .tagName("Spring")
+                    .shareable("true")
+                    .build();
+            
+            MvcResult mvcResult = mockMvc.perform(post("/api/tags")
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content(objectMapper.writeValueAsString(tagRequest)))
+                    .andExpect(status().is(409))
+                    .andReturn();
+            
+            logger.info(mvcResult.getResponse().getContentAsString());
+        }
+    }
+    
+    @Nested
+    @DisplayName("태그 수정")
+    
+    class SetTag {
+        
+        @Test
+        @DisplayName("수정 Response")
+        @WithMockMember(id = 1, email = "marrin1101@naver.com")
+        void responseTest() throws Exception {
+            TagRequest tagRequest = TagRequest.builder()
+                    .tagName("Summer")
+                    .shareable("false")
+                    .build();
+            
+            MvcResult mvcResult = mockMvc.perform(put("/api/tags/1")
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content(objectMapper.writeValueAsString(tagRequest)))
+                    .andExpect(status().is(200))
+                    .andReturn();
+            
+            logger.info(mvcResult.getResponse().getContentAsString());
+        }
+        
+        @Test
+        @DisplayName("없는데 수정 예외 핸들러")
+        @WithMockMember(id = 1, email = "marrin1101@naver.com")
+        void responseExceptionTest() throws Exception {
+            TagRequest tagRequest = TagRequest.builder()
+                    .tagName("Summer")
+                    .shareable("false")
+                    .build();
+            
+            MvcResult mvcResult = mockMvc.perform(put("/api/tags/4")
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content(objectMapper.writeValueAsString(tagRequest)))
+                    .andExpect(status().is(409))
+                    .andReturn();
+            
+            logger.info(mvcResult.getResponse().getContentAsString());
+        }
+    }
+    
+    @Nested
+    @DisplayName("태그 삭제")
+    class DeleteTag {
+        
+        @DisplayName("삭제 Response")
+        @Test
+        @WithMockMember(id = 1, email = "marrin1101@naver.com")
+        void responseTest() throws Exception {
+            MvcResult mvcResult = mockMvc.perform(delete("/api/tags/1")
+                    )
+                    .andExpect(status().is(200))
+                    .andReturn();
+            
+            logger.info(mvcResult.getResponse().getContentAsString());
+        }
+        
+        @DisplayName("없는데 삭제 예외 핸들러")
+        @Test
+        @WithMockMember(id = 1, email = "marrin1101@naver.com")
+        void responseExceptionTest() throws Exception {
+            MvcResult mvcResult = mockMvc.perform(delete("/api/tags/5")
+                    )
+                    .andExpect(status().is(409))
+                    .andReturn();
+            
+            logger.info(mvcResult.getResponse().getContentAsString());
+        }
+    }
+}

--- a/src/test/java/com/wnis/linkyway/controller/tag/TagControllerTest.java
+++ b/src/test/java/com/wnis/linkyway/controller/tag/TagControllerTest.java
@@ -1,0 +1,135 @@
+package com.wnis.linkyway.controller.tag;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.wnis.linkyway.dto.tag.TagRequest;
+import com.wnis.linkyway.exception.error.ErrorResponse;
+import com.wnis.linkyway.repository.MemberRepository;
+import com.wnis.linkyway.security.testutils.WithMockMember;
+import com.wnis.linkyway.service.tag.TagService;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.MvcResult;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+import org.springframework.web.context.WebApplicationContext;
+
+import javax.transaction.Transactional;
+
+import static com.wnis.linkyway.utils.ResponseBodyMatchers.responseBody;
+import static org.springframework.security.test.web.servlet.setup.SecurityMockMvcConfigurers.springSecurity;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@SpringBootTest
+@Transactional
+@AutoConfigureMockMvc
+class TagControllerTest {
+    
+    private final static Logger logger = LoggerFactory.getLogger(TagControllerTest.class);
+    
+    @MockBean
+    private TagService tagService;
+    
+    @Autowired
+    private ObjectMapper objectMapper;
+    
+    @Autowired
+    private MemberRepository memberRepository;
+    
+    @Autowired
+    private WebApplicationContext context;
+    
+    @Autowired
+    private MockMvc mockMvc;
+    
+    @BeforeEach
+    private void before() {
+        mockMvc =
+                MockMvcBuilders
+                        .webAppContextSetup(context)
+                        .apply(springSecurity())
+                        .alwaysDo(print())
+                        .build();
+    }
+    
+    
+    @Nested
+    @DisplayName("1. HttpRequest 테스트")
+    class HttpRequestTest {
+        
+        @Test
+        @DisplayName("HttpRequest 성공 테스트")
+        @WithMockMember(id = 1L)
+        void httpRequestSuccessTest() throws Exception {
+            TagRequest tagRequest = TagRequest.builder().tagName("스프링").shareable("true").build();
+            
+            mockMvc.perform(post("/api/tags").contentType("application/json").content(objectMapper.writeValueAsString(tagRequest))).andExpect(status().isOk());
+        }
+        
+        @Test
+        @DisplayName("post 요청 시 HttpRequest 바디가 없는 경우 테스트")
+        void httpRequestFail_NoBodyCaseTest() throws Exception {
+            TagRequest tagRequest = TagRequest.builder().tagName("스프링").shareable("true").build();
+            
+            mockMvc.perform(post("/api/tags").contentType("application/json")).andExpect(status().is(400));
+            
+        }
+        
+        @Test
+        @DisplayName("HttpRequest Http Method를 잘못 요청한 경우 테스트")
+        void httpRequestFail_IllegalHttpMethodCaseTest() throws Exception {
+            TagRequest tagRequest = TagRequest.builder().tagName("스프링").shareable("true").build();
+            
+            mockMvc.perform(put("/api/tags").contentType("application/json")).andExpect(status().is(405));
+        }
+        
+        @Test
+        @DisplayName("HttpRequest Mapping하지 않는 URI가 들어온 경우 테스트")
+        void httpRequestFail_NotFoundCaseTest() throws Exception {
+            MvcResult ret = mockMvc.perform(post("/apia/tags").contentType("application/json"))
+                    .andExpect(status().is(404))
+                    .andReturn();
+            
+        }
+    }
+    
+    @Nested
+    @DisplayName("2. Validation 테스트")
+    class ValidationTest {
+        @ParameterizedTest
+        @CsvSource(value = {"'', ''", "tagName, ''", "' ', shreable"})
+        @DisplayName("빈 값 테스트")
+        void nullTest(String tagName, String shareable) throws Exception {
+            TagRequest tagRequest = TagRequest.builder().tagName(tagName).shareable(shareable).build();
+            
+            MvcResult mvcResult = mockMvc.perform(post("/api/tags").contentType("application/json").content(objectMapper.writeValueAsString(tagRequest))).andExpect(status().is(400)).andExpect(responseBody().containsPropertiesAsJson(ErrorResponse.class)) // body의
+                    .andReturn();
+            
+        }
+        
+        @ParameterizedTest
+        @CsvSource(value = {"'aa', ' '", "aa, 'true1'", "'aa', false2"})
+        @DisplayName("패턴 테스트")
+        void patternTest(String tagName, String shareable) throws Exception {
+            TagRequest tagRequest = TagRequest.builder().tagName(tagName).shareable(shareable).build();
+            
+            MvcResult mvcResult = mockMvc.perform(post("/api/tags").contentType("application/json").content(objectMapper.writeValueAsString(tagRequest))).andExpect(status().is(400)).andExpect(responseBody().containsPropertiesAsJson(ErrorResponse.class)) // body의
+                    .andReturn();
+            
+        }
+    }
+    
+    
+}

--- a/src/test/java/com/wnis/linkyway/service/tag/TagServiceImplTest.java
+++ b/src/test/java/com/wnis/linkyway/service/tag/TagServiceImplTest.java
@@ -1,0 +1,237 @@
+package com.wnis.linkyway.service.tag;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.wnis.linkyway.dto.Response;
+import com.wnis.linkyway.dto.tag.TagRequest;
+import com.wnis.linkyway.entity.Member;
+import com.wnis.linkyway.entity.Tag;
+import com.wnis.linkyway.exception.common.ResourceConflictException;
+import com.wnis.linkyway.repository.MemberRepository;
+import com.wnis.linkyway.repository.TagRepository;
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.test.context.jdbc.Sql;
+
+import javax.persistence.EntityManager;
+import java.util.Arrays;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+@DataJpaTest
+@Import(TagServiceImpl.class)
+@AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
+@Sql("/sqltest/initialize-test.sql")
+class TagServiceImplTest {
+    
+    @Autowired
+    TagService tagService;
+    
+    @Autowired
+    MemberRepository memberRepository;
+    
+    @Autowired
+    TagRepository tagRepository;
+    
+    @Autowired
+    EntityManager entityManager;
+    
+    @Nested
+    @DisplayName("태그 추가 테스트")
+    class addTagTest {
+        
+        @Test
+        @DisplayName("중복에 의한 예외 상황")
+        void failTest() {
+            TagRequest tagRequest = TagRequest.builder()
+                    .tagName("spring")
+                    .build();
+            Member member = Member.builder()
+                    .email("hello@naver.com")
+                    .nickname("aasd12")
+                    .password("a!asdD@12321")
+                    .build();
+            Tag tag = Tag.builder()
+                    .member(member)
+                    .name("spring")
+                    .shareable(true)
+                    .build();
+            
+            tagRepository.save(tag);
+            memberRepository.save(member);
+            assertThatThrownBy(() -> {
+                tagService.addTag(tagRequest, 1L);
+            }).isInstanceOf(ResourceConflictException.class);
+            
+        }
+        
+        @Test
+        @DisplayName("성공 테스트")
+        void successTest() {
+            TagRequest tagRequest = TagRequest.builder()
+                    .tagName("spring")
+                    .build();
+            Member member = Member.builder()
+                    .email("hello@naver.com")
+                    .nickname("aasd12")
+                    .password("a!asdD@12321")
+                    .build();
+            Tag tag = Tag.builder()
+                    .member(member)
+                    .name("food")
+                    .shareable(true)
+                    .build();
+            
+            memberRepository.save(member);
+            tagRepository.save(tag);
+            
+            
+            tagService.addTag(tagRequest, 1L);
+            tagRepository.findAll().forEach((t) -> {
+                assertThat(t).isNotNull();
+                assertThat(t.getMember().getId()).isEqualTo(1L);
+            });
+        }
+    }
+    
+    @Nested
+    @DisplayName("태그 수정 테스트")
+    class setTagTest {
+        
+        @Test
+        @DisplayName("수정 성공한 경우")
+        void successTest() {
+            TagRequest tagRequest = TagRequest.builder()
+                    .tagName("spring")
+                    .shareable("true")
+                    .build();
+            Member member = Member.builder()
+                    .email("hello@naver.com")
+                    .nickname("aasd12")
+                    .password("a!asdD@12321")
+                    .build();
+            Tag tag = Tag.builder()
+                    .member(member)
+                    .name("food")
+                    .shareable(true)
+                    .build();
+            tagRepository.save(tag);
+            
+            tagService.setTag(tagRequest, 1L);
+            assertThat(tagRepository.findById(1L).get()).isInstanceOfSatisfying(Tag.class, (t) -> {
+                assertThat(tag.getName()).isEqualTo("spring");
+                assertThat(tag.getShareable()).isEqualTo(true);
+            });
+        }
+        
+        @Test
+        @DisplayName("데이터가 없어서 수정 실패한 경우")
+        void failTest() {
+            TagRequest tagRequest = TagRequest.builder()
+                    .tagName("spring")
+                    .shareable("true")
+                    .build();
+            Member member = Member.builder()
+                    .email("hello@naver.com")
+                    .nickname("aasd12")
+                    .password("a!asdD@12321")
+                    .build();
+            Tag tag = Tag.builder()
+                    .member(member)
+                    .name("food")
+                    .shareable(true)
+                    .build();
+            tagRepository.save(tag);
+            
+            Assertions.assertThatThrownBy(() -> {
+                tagService.setTag(tagRequest, 2L);
+            }).isInstanceOf(ResourceConflictException.class);
+        }
+    }
+    
+    @Nested
+    @DisplayName("태그 삭제 테스트")
+    class DeleteTagTest {
+        
+        @Test
+        @DisplayName("삭제 성공")
+        void successTest() {
+            TagRequest tagRequest = TagRequest.builder()
+                    .tagName("spring")
+                    .shareable("true")
+                    .build();
+            Member member = Member.builder()
+                    .email("hello@naver.com")
+                    .nickname("aasd12")
+                    .password("a!asdD@12321")
+                    .build();
+            Tag tag1 = Tag.builder()
+                    .name("food")
+                    .shareable(true)
+                    .build();
+            
+            Tag tag2 = Tag.builder()
+                    .name("food2")
+                    .shareable(true)
+                    .build();
+            
+            member.addTag(tag1);
+            member.addTag(tag2);
+            
+            memberRepository.save(member);
+            tagRepository.save(tag1);
+            tagRepository.save(tag2);
+            
+            tagService.deleteTag(1L);
+            assertThat(tagRepository.findAll().size()).isEqualTo(1);
+        }
+    }
+    
+    @Nested
+    @DisplayName("태그 조회 테스트")
+    class SearchTagsTest {
+        
+        @Test
+        @DisplayName("태그 조회 테스트")
+        void successTest() throws JsonProcessingException {
+            Member member = Member.builder()
+                    .email("hello@naver.com")
+                    .nickname("aasd12")
+                    .password("a!asdD@12321")
+                    .build();
+            Tag tag1 = Tag.builder()
+                    .name("food")
+                    .shareable(true)
+                    .build();
+            
+            Tag tag2 = Tag.builder()
+                    .name("food2")
+                    .shareable(false)
+                    .build();
+            
+            Tag tag3 = Tag.builder()
+                    .name("food3")
+                    .shareable(true)
+                    .build();
+            
+            member.addTag(tag1)
+                    .addTag(tag2)
+                    .addTag(tag3);
+            
+            memberRepository.save(member);
+            tagRepository.saveAll(Arrays.asList(tag1, tag2, tag3));
+            
+            Response tagResponseList = tagService.searchTags(1L);
+            ObjectMapper objectMapper = new ObjectMapper();
+            String s = objectMapper.writeValueAsString(tagResponseList);
+            System.out.println(s);
+        }
+    }
+}


### PR DESCRIPTION
- 최대한 API 문서 설계대로 구현하려 노력했습니다.
- 큰 특이사항은 없고  Jqpl 부분을 잘 활용하거나 querydsl을 활용하면 dto로 바로 리턴 할 수 있다고 하는데 고민 해보겠습니다.
- service test에서 로직과 응답 예외 테스트 모두 했습니다.
- 405 응답을 좀 더 명확하게 하기 위해서 태그 조회에 /table을 넣어서 post와 차이점을 두었습니다.