### PR TITLE
Feat/#25/folder

### DIFF
--- a/src/main/java/com/wnis/linkyway/controller/FolderController.java
+++ b/src/main/java/com/wnis/linkyway/controller/FolderController.java
@@ -1,0 +1,76 @@
+package com.wnis.linkyway.controller;
+
+import com.wnis.linkyway.dto.Response;
+import com.wnis.linkyway.dto.folder.AddFolderRequest;
+import com.wnis.linkyway.dto.folder.FolderResponse;
+import com.wnis.linkyway.dto.folder.SetFolderNameRequest;
+import com.wnis.linkyway.dto.folder.SetFolderPathRequest;
+import com.wnis.linkyway.security.annotation.Authenticated;
+import com.wnis.linkyway.security.annotation.CurrentMember;
+import com.wnis.linkyway.service.folder.FolderService;
+import com.wnis.linkyway.validation.ValidationSequence;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api")
+public class FolderController {
+    
+    private final FolderService folderService;
+    
+    @GetMapping("/folders/{folderId}")
+    @Authenticated
+    ResponseEntity<Response> searchFolder(@PathVariable(value = "folderId") Long folderId) {
+        Response<FolderResponse> folderResponse = folderService.findFolder(folderId);
+        return ResponseEntity.ok(folderResponse);
+    }
+    
+    @PostMapping("/folders/super")
+    @Authenticated
+    ResponseEntity<Response> addSuperFolder(
+            @CurrentMember Long memberId) {
+    
+        Response<FolderResponse> folderResponse = folderService.addSuperFolder(memberId);
+        return ResponseEntity.ok(folderResponse);
+    }
+    
+    @PostMapping("/folders")
+    @Authenticated
+    ResponseEntity<Response> addFolder(
+            @Validated(ValidationSequence.class) @RequestBody AddFolderRequest addFolderRequest,
+            @CurrentMember Long memberId) {
+        
+        Response<FolderResponse> folderResponse = folderService.addFolder(addFolderRequest, memberId);
+        return ResponseEntity.ok(folderResponse);
+    }
+    
+    @PutMapping("/folders/{folderId}/name")
+    @Authenticated
+    ResponseEntity<Response> setFolderName(
+            @Validated(ValidationSequence.class) @RequestBody SetFolderNameRequest setFolderNameRequest,
+            @PathVariable Long folderId) {
+        
+        Response<FolderResponse> folderResponse = folderService.setFolderName(setFolderNameRequest, folderId);
+        return ResponseEntity.ok(folderResponse);
+    }
+    
+    @PutMapping("/folders/{folderId}/path")
+    @Authenticated
+    ResponseEntity<Response> setFolderPath(
+            @Validated(ValidationSequence.class) @RequestBody SetFolderPathRequest setFolderPathRequest,
+            @PathVariable(value = "folderId") Long folderId) {
+        
+        Response<FolderResponse> folderResponse = folderService.setFolderPath(setFolderPathRequest, folderId);
+        return ResponseEntity.ok(folderResponse);
+    }
+    
+    @DeleteMapping("/folders/{folderId}")
+    @Authenticated
+    ResponseEntity<Response> deleteFolder(@PathVariable(value = "folderId") Long folderId) {
+        Response<FolderResponse> folderResponse = folderService.deleteFolder(folderId);
+        return ResponseEntity.ok(folderResponse);
+    }
+}

--- a/src/main/java/com/wnis/linkyway/controller/TagController.java
+++ b/src/main/java/com/wnis/linkyway/controller/TagController.java
@@ -1,0 +1,63 @@
+package com.wnis.linkyway.controller;
+
+import com.wnis.linkyway.dto.Response;
+import com.wnis.linkyway.dto.tag.TagRequest;
+import com.wnis.linkyway.security.annotation.Authenticated;
+import com.wnis.linkyway.security.annotation.CurrentMember;
+import com.wnis.linkyway.service.tag.TagService;
+import com.wnis.linkyway.validation.ValidationSequence;
+import io.swagger.annotations.ApiOperation;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.*;
+import springfox.documentation.annotations.ApiIgnore;
+
+@RequiredArgsConstructor
+@RestController
+@RequestMapping("/api")
+public class TagController {
+    
+    private final TagService tagService;
+    
+    @GetMapping("/tags/table")
+    @ApiOperation(value = "태그 조회", notes = "해당 회원이 가지고 있는 태그 리스트를 조회한다.")
+    @Authenticated
+    public ResponseEntity<Response> searchTags(@ApiIgnore @CurrentMember Long memberId) {
+        Response response = tagService.searchTags(memberId);
+        return ResponseEntity.ok(response);
+    }
+    
+    @PostMapping("/tags")
+    @ApiOperation(value = "태그 추가", notes = "해당 회원이 가지고 있는 태그를 추가한다.")
+    @Authenticated
+    public ResponseEntity<Response> addTag(
+            @ApiIgnore @CurrentMember Long memberId,
+            @Validated(ValidationSequence.class) @RequestBody TagRequest tagRequest) {
+        
+        Response response = tagService.addTag(tagRequest, memberId);
+        return ResponseEntity.ok(response);
+    }
+    
+    @PutMapping("/tags/{tagId}")
+    @ApiOperation(value = "태그 수정", notes = "해당 회원이 가지고 있는 태그를 수정한다.")
+    @Authenticated
+    public ResponseEntity<Response> setTag(
+            @ApiIgnore @CurrentMember Long memberId,
+            @PathVariable(value = "tagId") Long tagId,
+            @RequestBody TagRequest tagRequest) {
+        
+        Response response = tagService.setTag(tagRequest, tagId);
+        return ResponseEntity.ok(response);
+    }
+    
+    @DeleteMapping("/tags/{tagId}")
+    @ApiOperation(value = "태그 삭제", notes = "해당 회원이 가지오 있는 태그를 삭제한다.")
+    @Authenticated
+    public ResponseEntity<Response> deleteTag(
+            @PathVariable(value = "tagId") Long tagId) {
+        
+        Response response = tagService.deleteTag(tagId);
+        return ResponseEntity.ok(response);
+    }
+}

--- a/src/main/java/com/wnis/linkyway/dto/folder/AddFolderRequest.java
+++ b/src/main/java/com/wnis/linkyway/dto/folder/AddFolderRequest.java
@@ -1,0 +1,27 @@
+package com.wnis.linkyway.dto.folder;
+
+
+import com.wnis.linkyway.validation.ValidationGroup;
+import lombok.*;
+
+import javax.validation.constraints.NotBlank;
+import javax.validation.constraints.NotNull;
+import javax.validation.constraints.Pattern;
+import javax.validation.constraints.Positive;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+@Builder
+public class AddFolderRequest {
+    
+    @NotNull(message = "부모 폴더 id를 입력해주세요", groups = ValidationGroup.NotBlankGroup.class)
+    @Positive(message = "parentFolderId는 0 이상의 id를 입력하셔야 합니다.")
+    private Long parentFolderId;
+    
+    @NotBlank(message = "추가할 폴더 이름을 입력해주세요", groups = ValidationGroup.NotBlankGroup.class)
+    @Pattern(regexp = "^[ㄱ-ㅎ가-힣a-zA-Z\\d_]{1,10}$",
+            message = "추가 하실 폴더 이름은 한글,영어,숫자_ 포함 10글자 이하로 입력해주세요",
+            groups = ValidationGroup.PatternCheckGroup.class)
+    private String name;
+}

--- a/src/main/java/com/wnis/linkyway/dto/folder/FolderResponse.java
+++ b/src/main/java/com/wnis/linkyway/dto/folder/FolderResponse.java
@@ -2,18 +2,78 @@ package com.wnis.linkyway.dto.folder;
 
 
 import com.fasterxml.jackson.annotation.JsonInclude;
+import com.wnis.linkyway.entity.Folder;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+
+import java.util.ArrayDeque;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Queue;
 
 @Getter
 @NoArgsConstructor
 @JsonInclude(JsonInclude.Include.NON_EMPTY)
 public class FolderResponse {
-
+    
     Long folderId;
     Long parentId;
-    int level;
+    Long level;
     String name;
-
-
+    
+    List<FolderResponse> childFolderList = new ArrayList<>();
+    
+    @Builder
+    private FolderResponse(Long folderId, Long parentId, Long level, String name) {
+        this.folderId = folderId;
+        this.parentId = parentId;
+        this.level = level;
+        this.name = name;
+    }
+    
+    public FolderResponse(Folder folder) {
+        this.folderId = folder.getId();
+        if (folder.getParent() == null) {
+            this.parentId = null;
+        } else {
+            this.parentId = folder.getParent().getId();
+        }
+        this.level = folder.getDepth();
+        this.childFolderList = makeDirectoryTree(folder);
+    }
+    
+    private FolderResponse makeFolderResponse(Folder folder) {
+        return FolderResponse.builder()
+                .folderId(folder.getId())
+                .parentId(folder.getParent().getId())
+                .level(folder.getDepth())
+                .build();
+    }
+    
+    private List<FolderResponse> makeDirectoryTree(Folder folder) {
+        Queue<Folder> queue1 = new ArrayDeque<>();
+        Queue<FolderResponse> queue2 = new ArrayDeque<>();
+        folder.getChildren().forEach((f) -> {
+            queue1.add(f);
+            FolderResponse newFolderResponse = makeFolderResponse(f);
+            this.getChildFolderList().add(newFolderResponse);
+            queue2.add(newFolderResponse);
+        });
+        
+        while (!queue1.isEmpty()) {
+            Folder currentFolder = queue1.poll();
+            FolderResponse currentFolderResponse = queue2.poll();
+            
+            for (Folder f : currentFolder.getChildren()) {
+                FolderResponse newFolderResponse = makeFolderResponse(f);
+                currentFolderResponse.getChildFolderList().add(newFolderResponse);
+                queue1.add(f);
+                queue2.add(newFolderResponse);
+            }
+        }
+        return this.childFolderList;
+    }
+    
+    
 }

--- a/src/main/java/com/wnis/linkyway/dto/folder/SetFolderNameRequest.java
+++ b/src/main/java/com/wnis/linkyway/dto/folder/SetFolderNameRequest.java
@@ -1,0 +1,23 @@
+package com.wnis.linkyway.dto.folder;
+
+import com.wnis.linkyway.validation.ValidationGroup.NotBlankGroup;
+import com.wnis.linkyway.validation.ValidationGroup.PatternCheckGroup;
+import lombok.*;
+
+import javax.validation.constraints.NotBlank;
+import javax.validation.constraints.Pattern;
+
+@Getter
+@Builder
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+@NoArgsConstructor
+public class SetFolderNameRequest {
+    
+    @NotBlank(message = "변경하실 폴더 이름을 입력해주세요",
+            groups = NotBlankGroup.class)
+    @Pattern(regexp = "^[ㄱ-ㅎ가-힣a-zA-Z\\d_]{1,10}$",
+            message = "변경하실 폴더 이름은 한글,영어,숫자_ 포함 10글자 이하로 입력해주세요",
+            groups = PatternCheckGroup.class)
+    private String name;
+    
+}

--- a/src/main/java/com/wnis/linkyway/dto/folder/SetFolderPathRequest.java
+++ b/src/main/java/com/wnis/linkyway/dto/folder/SetFolderPathRequest.java
@@ -1,0 +1,19 @@
+package com.wnis.linkyway.dto.folder;
+
+import com.wnis.linkyway.validation.ValidationGroup.NotBlankGroup;
+import lombok.*;
+
+import javax.validation.constraints.NotNull;
+import javax.validation.constraints.Positive;
+
+@Getter
+@Builder
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+@NoArgsConstructor
+public class SetFolderPathRequest {
+    
+    @NotNull(message = "타겟 상위 폴더의 id를 입력해주세요",
+            groups = NotBlankGroup.class)
+    @Positive(message = "targetFolderId는 1 이상의 id를 입력하셔야 합니다.")
+    private Long targetFolderId;
+}

--- a/src/main/java/com/wnis/linkyway/dto/tag/TagRequest.java
+++ b/src/main/java/com/wnis/linkyway/dto/tag/TagRequest.java
@@ -1,26 +1,25 @@
 package com.wnis.linkyway.dto.tag;
 
 
-import com.wnis.linkyway.validation.ValidationGroup;
 import lombok.*;
 
 import javax.validation.constraints.NotBlank;
 import javax.validation.constraints.Pattern;
 import javax.validation.constraints.Size;
 
-import static com.wnis.linkyway.validation.ValidationGroup.*;
+import static com.wnis.linkyway.validation.ValidationGroup.NotBlankGroup;
+import static com.wnis.linkyway.validation.ValidationGroup.PatternCheckGroup;
 
 @Getter
 @NoArgsConstructor
 @AllArgsConstructor(access = AccessLevel.PRIVATE)
 @Builder
 public class TagRequest {
-
-    @NotBlank(message = "tagName을 입력해주세요", groups = NotBlankGroup.class)
-    @Size(max = 10, message = "10자 이하로 작성해주세요")
-    private String tagName;
-
+    
     @NotBlank(message = "소셜 공유 여부를 입력해주세요", groups = NotBlankGroup.class)
     @Pattern(regexp = "(true|false)", groups = PatternCheckGroup.class)
     String shareable;
+    @NotBlank(message = "tagName을 입력해주세요", groups = NotBlankGroup.class)
+    @Size(max = 10, message = "10자 이하로 작성해주세요")
+    private String tagName;
 }

--- a/src/main/java/com/wnis/linkyway/dto/tag/TagResponse.java
+++ b/src/main/java/com/wnis/linkyway/dto/tag/TagResponse.java
@@ -2,21 +2,20 @@ package com.wnis.linkyway.dto.tag;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.wnis.linkyway.entity.Tag;
-import lombok.*;
-
-import java.util.ArrayList;
-import java.util.List;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
 
 @Getter
 @NoArgsConstructor
 @JsonInclude(JsonInclude.Include.NON_EMPTY)
 public class TagResponse {
-
+    
     private Long tagId;
     private String tagName;
     private Boolean shareable;
     private Integer views;
-
+    
     @Builder
     private TagResponse(Long tagId, String tagName,
                         Boolean shareable, Integer views) {
@@ -25,7 +24,7 @@ public class TagResponse {
         this.shareable = shareable;
         this.views = views;
     }
-
+    
     public TagResponse(Tag tag) {
         this.tagId = tag.getId();
         this.tagName = tag.getName();

--- a/src/main/java/com/wnis/linkyway/entity/Folder.java
+++ b/src/main/java/com/wnis/linkyway/entity/Folder.java
@@ -1,9 +1,12 @@
 package com.wnis.linkyway.entity;
 
-import lombok.*;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
 
 import javax.persistence.*;
-import java.util.*;
+import java.util.ArrayList;
+import java.util.List;
 
 @NoArgsConstructor
 @Getter
@@ -14,44 +17,83 @@ public class Folder {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     @Column(name = "folder_id", nullable = false)
     private Long id;
-
+    
     @Column(name = "name")
     private String name;
-
+    
+    @Column(name = "depth")
+    private Long depth;
+    
     ////********************연관 관게  ***************************/////
-
+    
     // ***** 1 : N *****
-    @OneToMany(mappedBy = "parent")
+    @OneToMany(mappedBy = "parent", cascade = CascadeType.REMOVE)
     private List<Folder> children = new ArrayList<>();
-
-    @OneToMany(mappedBy = "folder")
+    
+    @OneToMany(mappedBy = "folder", cascade = CascadeType.REMOVE)
     private List<Card> cards = new ArrayList<>();
-
-
-
+    
+    
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "parent_folder_id")
     private Folder parent;
-
+    
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "member_member_id")
     private Member member;
-
-
-
-
+    
+    // ********연관관계 메소드 *************************
+    
     // ***************** 생성자 ****************************
     @Builder
-    private Folder(String name, Folder parent, Member member) {
+    private Folder(String name, Long depth, Folder parent, Member member) {
         this.name = name;
-
+        this.depth = depth;
+        
         this.parent = parent;
         if (parent != null)
             parent.getChildren().add(this);
-
+        
         this.member = member;
         if (member != null) {
             member.getFolders().add(this);
         }
+    }
+    
+    public Folder modifyParent(Folder destination) {
+        if (destination == null) {
+            throw new NullPointerException("널 폴더에 연결 할 수 없습니다.");
+        }
+        
+        if (destination.isDirectAncestor(this)) {
+            throw new IllegalStateException("순환 참조 위험성이 있습니다.");
+        }
+        
+        // 기존 부모 자식연결 부분에서 현재 폴더 엔티티 제거
+        Folder parent = this.getParent();
+        parent.getChildren().removeIf((f) -> f.getId() == this.getId());
+        
+        this.parent = destination; // 현재 폴더의 부모를 destination 설정
+        destination.getChildren().add(this); // destination 자식에 현재 폴더 엔티티 추가
+        
+        return this;
+    }
+    
+    public boolean isDirectAncestor(Folder folder) {
+        Folder currentFolder = this;
+        Folder parent = currentFolder.getParent();
+        while (parent != null) {
+            if (parent.getId() == folder.getId()) {
+                return true;
+            }
+            parent = parent.getParent();
+        }
+        return false;
+    }
+    
+    // **************** 접근자 ************************
+    public Folder updateName(String name) {
+        this.name = name;
+        return this;
     }
 }

--- a/src/main/java/com/wnis/linkyway/repository/FolderRepository.java
+++ b/src/main/java/com/wnis/linkyway/repository/FolderRepository.java
@@ -3,16 +3,26 @@ package com.wnis.linkyway.repository;
 
 import com.wnis.linkyway.entity.Folder;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 import java.util.List;
 
 public interface FolderRepository extends JpaRepository<Folder, Long> {
-    @Query("select f from Folder as f left outer join fetch f.parent")
-    public List<Folder> findAllEagerly();
-
-    @Query("select f from Folder f join fetch f.member")
-    public List<Folder> findAllIncludeMember();
-
-
+    
+    @Query("select f from Folder f join f.member as m " +
+            "left outer join fetch f.parent" +
+            " where m.id = :memberId")
+    public List<Folder> findFoldersByMemberId(@Param("memberId") Long memberId);
+    
+    @Query("select f from Folder f left outer join fetch f.parent " +
+            "where f.id = :folderId")
+    public Folder findFolderById(@Param("folderId") Long folderId);
+    
+    @Modifying
+    @Query(value = "insert into folder (name, depth, parent_folder_id, member_member_id) " +
+            "values ('default', 1, null, :memberId)", nativeQuery = true)
+    public void addSuperFolder(@Param("memberId") Long memberId);
+    
 }

--- a/src/main/java/com/wnis/linkyway/repository/TagRepository.java
+++ b/src/main/java/com/wnis/linkyway/repository/TagRepository.java
@@ -1,14 +1,32 @@
 package com.wnis.linkyway.repository;
 
 
+import com.wnis.linkyway.dto.tag.TagResponse;
 import com.wnis.linkyway.entity.Tag;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 import java.util.List;
 
 public interface TagRepository extends JpaRepository<Tag, Long> {
     @Query("select t from Tag t join fetch t.member")
-    List<Tag> findAllIncludesTag();
-
+    public List<Tag> findAllIncludesTag();
+    
+    @Query("select new com.wnis.linkyway.dto.tag.TagResponse(t) " +
+            "from Tag t join t.member where t.member.id = :memberId")
+    public List<TagResponse> findAllTagList(@Param("memberId") Long memberId);
+    
+    @Query("select t from Tag t join fetch t.member " +
+            "where t.name = :name and t.member.id = :id")
+    public Tag findByTagNameAndMemberId(@Param(value = "name") String name,
+                                        @Param(value = "id") Long id);
+    
+    @Modifying
+    @Query(value = "insert into tag (name, shareable, views, member_member_id)" +
+            "values (:name, :shareable, 0, :member_id)", nativeQuery = true)
+    public void addTag(@Param("name") String name,
+                       @Param("shareable") boolean shareable,
+                       @Param("member_id") Long memberId);
 }

--- a/src/main/java/com/wnis/linkyway/service/folder/FolderService.java
+++ b/src/main/java/com/wnis/linkyway/service/folder/FolderService.java
@@ -1,0 +1,22 @@
+package com.wnis.linkyway.service.folder;
+
+
+import com.wnis.linkyway.dto.Response;
+import com.wnis.linkyway.dto.folder.AddFolderRequest;
+import com.wnis.linkyway.dto.folder.FolderResponse;
+import com.wnis.linkyway.dto.folder.SetFolderNameRequest;
+import com.wnis.linkyway.dto.folder.SetFolderPathRequest;
+
+public interface FolderService {
+    
+    Response<FolderResponse> findFolder(Long folderId);
+    Response<FolderResponse> addSuperFolder(Long memberId);
+    
+    Response<FolderResponse> addFolder(AddFolderRequest addFolderRequest, Long memberId);
+    
+    Response<FolderResponse> setFolderPath(SetFolderPathRequest setFolderPathRequest, Long folderId);
+    
+    Response<FolderResponse> setFolderName(SetFolderNameRequest setFolderNameRequest, Long folderId);
+    
+    Response<FolderResponse> deleteFolder(Long folderId);
+}

--- a/src/main/java/com/wnis/linkyway/service/folder/FolderServiceImpl.java
+++ b/src/main/java/com/wnis/linkyway/service/folder/FolderServiceImpl.java
@@ -1,0 +1,109 @@
+package com.wnis.linkyway.service.folder;
+
+import com.wnis.linkyway.dto.Response;
+import com.wnis.linkyway.dto.folder.AddFolderRequest;
+import com.wnis.linkyway.dto.folder.FolderResponse;
+import com.wnis.linkyway.dto.folder.SetFolderNameRequest;
+import com.wnis.linkyway.dto.folder.SetFolderPathRequest;
+import com.wnis.linkyway.entity.Folder;
+import com.wnis.linkyway.entity.Member;
+import com.wnis.linkyway.exception.common.ResourceConflictException;
+import com.wnis.linkyway.repository.FolderRepository;
+import com.wnis.linkyway.repository.MemberRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.stereotype.Service;
+
+import javax.transaction.Transactional;
+
+@Service("folderService")
+@RequiredArgsConstructor
+@Transactional
+public class FolderServiceImpl implements FolderService {
+    
+    private final FolderRepository folderRepository;
+    private final MemberRepository memberRepository;
+    
+    @Override
+    public Response<FolderResponse> findFolder(Long folderId) {
+        Folder folder = folderRepository.findFolderById(folderId);
+        if (folder == null) {
+            throw new ResourceConflictException("해당 회원의 폴더가 존재하지 않아 조회 할 수 없습니다.");
+        }
+        FolderResponse folderResponse = new FolderResponse(folder);
+        return Response.of(HttpStatus.OK, folderResponse, "폴더를 성공적으로 조회했습니다.");
+    }
+    
+    @Override
+    public Response<FolderResponse> addSuperFolder(Long memberId) {
+        folderRepository.addSuperFolder(memberId);
+        return Response.of(HttpStatus.OK, null, "default 폴더 생성 성공");
+    }
+    
+    @Override
+    public Response<FolderResponse> addFolder(AddFolderRequest addFolderRequest, Long memberId) {
+        Member member = memberRepository.findById(memberId).orElse(null);
+        if (member == null) {
+            throw new ResourceConflictException("회원이 존재하지 않습니다.");
+        }
+        Folder parent = folderRepository.findFolderById(addFolderRequest.getParentFolderId());
+        if (parent == null) {
+            throw new ResourceConflictException("존재 하지 않는 상위 폴더입니다.");
+        }
+        Folder folder = Folder.builder()
+                .member(member)
+                .name(addFolderRequest.getName())
+                .depth(parent.getDepth() + 1)
+                .parent(parent)
+                .build();
+        
+        Folder outputFolder = folderRepository.save(folder);
+        FolderResponse response = FolderResponse.builder()
+                .folderId(outputFolder.getParent().getId())
+                .build();
+        
+        return Response.of(HttpStatus.OK, response, "폴더 생성 성공");
+    }
+    
+    @Override
+    public Response<FolderResponse> setFolderPath(SetFolderPathRequest setFolderPathRequest, Long folderId) {
+        Folder folder = folderRepository.findFolderById(folderId);
+        if (folder == null) {
+            throw new ResourceConflictException("수정 하려는 폴더가 존재하지 않습니다.");
+        }
+        Folder destinationFolder = folderRepository.findFolderById(setFolderPathRequest.getTargetFolderId());
+        if (destinationFolder == null) {
+            throw new ResourceConflictException("목표 부모 폴더가 존재하지 않습니다.");
+        }
+        if (destinationFolder.isDirectAncestor(folder)) {
+            throw new ResourceConflictException("직계 자손을 목표 부모 폴더로 지정 할 수 없습니다.");
+        }
+        folder.modifyParent(destinationFolder);
+        folderRepository.save(folder);
+        return Response.of(HttpStatus.OK, null, "폴더 경로가 성공적으로 수정되었습니다.");
+        
+    }
+    
+    @Override
+    public Response<FolderResponse> setFolderName(SetFolderNameRequest setFolderNameRequest, Long folderId) {
+        Folder folder = folderRepository.findById(folderId).orElse(null);
+        if (folder == null) {
+            throw new ResourceConflictException("해당 폴더가 존재하지 않아 수정을 할 수 없습니다.");
+        }
+        folder.updateName(setFolderNameRequest.getName());
+        folderRepository.save(folder);
+        return Response.of(HttpStatus.OK, null, "폴더 이름이 성공적으로 수정되었습니다.");
+    }
+    
+    @Override
+    public Response<FolderResponse> deleteFolder(Long folderId) {
+        Folder folder = folderRepository.findById(folderId).orElse(null);
+        if (folder == null) {
+            throw new ResourceConflictException("해당 폴더가 존재하지 않아 삭제 할 수 없습니다.");
+        }
+        folderRepository.deleteById(folderId);
+        return Response.of(HttpStatus.OK, null, "폴더와 하위 폴더가 성공적으로 삭제되었습니다.");
+    }
+    
+    
+}

--- a/src/main/java/com/wnis/linkyway/service/tag/TagService.java
+++ b/src/main/java/com/wnis/linkyway/service/tag/TagService.java
@@ -1,0 +1,16 @@
+package com.wnis.linkyway.service.tag;
+
+import com.wnis.linkyway.dto.Response;
+import com.wnis.linkyway.dto.tag.TagRequest;
+
+public interface TagService {
+    
+    Response searchTags(Long memberId);
+    
+    Response addTag(TagRequest tagRequest, Long memberId);
+    
+    Response setTag(TagRequest tagRequest, Long tagId);
+    
+    Response deleteTag(Long tagId);
+    
+}

--- a/src/main/java/com/wnis/linkyway/service/tag/TagServiceImpl.java
+++ b/src/main/java/com/wnis/linkyway/service/tag/TagServiceImpl.java
@@ -1,0 +1,85 @@
+package com.wnis.linkyway.service.tag;
+
+import com.wnis.linkyway.dto.Response;
+import com.wnis.linkyway.dto.tag.TagRequest;
+import com.wnis.linkyway.dto.tag.TagResponse;
+import com.wnis.linkyway.entity.Tag;
+import com.wnis.linkyway.exception.common.ResourceConflictException;
+import com.wnis.linkyway.repository.MemberRepository;
+import com.wnis.linkyway.repository.TagRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+
+import javax.transaction.Transactional;
+import java.util.List;
+
+@Service("tagService")
+@Transactional
+@RequiredArgsConstructor
+@Slf4j
+public class TagServiceImpl implements TagService {
+    
+    private final TagRepository tagRepository;
+    
+    private final MemberRepository memberRepository;
+    
+    
+    @Override
+    public Response searchTags(Long memberId) {
+        List<TagResponse> tagList = tagRepository.findAllTagList(memberId);
+        return Response.<List<TagResponse>>builder()
+                .code(200)
+                .message("성공적으로 태그를 조회했습니다.")
+                .data(tagList)
+                .build();
+    }
+    
+    @Override
+    public Response addTag(TagRequest tagRequest, Long memberId) {
+        Tag tag = tagRepository.findByTagNameAndMemberId(tagRequest.getTagName(), memberId);
+        if (tag != null) {
+            throw new ResourceConflictException("입력 값이 이미 존재합니다.");
+        }
+        tagRepository.addTag(tagRequest.getTagName(), Boolean.parseBoolean(tagRequest.getShareable()), memberId);
+        Tag t = tagRepository.findByTagNameAndMemberId(tagRequest.getTagName(), memberId);
+        TagResponse tagResponse = TagResponse.builder()
+                .tagId(t.getId())
+                .build();
+        
+        return Response.<TagResponse>builder()
+                .code(200)
+                .message(String.format("%s 태그가 성공적으로 생성되었습니다.", t.getName()))
+                .data(tagResponse)
+                .build();
+        
+    }
+    
+    @Override
+    public Response setTag(TagRequest tagRequest, Long tagId) {
+        Tag tag = tagRepository.findById(tagId).orElse(null);
+        if (tag == null) {
+            throw new ResourceConflictException("태그가 존재하지 않아 수정 할 수 없습니다.");
+        }
+        tag.updateName(tagRequest.getTagName()).updateShareable(Boolean.parseBoolean(tagRequest.getShareable()));
+        Tag t = tagRepository.save(tag);
+        return Response.builder()
+                .code(200)
+                .message(String.format("%s 태그가 성공적으로 수정되었습니다.", t.getName()))
+                .build();
+    }
+    
+    @Override
+    public Response deleteTag(Long tagId) {
+        Tag tag = tagRepository.findById(tagId).orElse(null);
+        if (tag == null) {
+            throw new ResourceConflictException("태그가 존재하지 않아 삭제 할 수 없습니다.");
+        }
+        tagRepository.deleteById(tagId);
+        return Response.builder()
+                .code(200)
+                .message("성공적으로 삭제되었습니다.")
+                .build();
+    }
+    
+}

--- a/src/main/resources/sqltest/initialize-test.sql
+++ b/src/main/resources/sqltest/initialize-test.sql
@@ -1,0 +1,4 @@
+ALTER TABLE member auto_increment = 1;
+ALTER TABLE tag auto_increment = 1;
+ALTER TABLE card auto_increment = 1;
+ALTER TABLE folder auto_increment = 1;

--- a/src/test/java/com/wnis/linkyway/controller/folder/FolderControllerIntegrationTest.java
+++ b/src/test/java/com/wnis/linkyway/controller/folder/FolderControllerIntegrationTest.java
@@ -1,0 +1,343 @@
+package com.wnis.linkyway.controller.folder;
+
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.wnis.linkyway.controller.tag.TagControllerIntegrationTest;
+import com.wnis.linkyway.dto.folder.AddFolderRequest;
+import com.wnis.linkyway.dto.folder.SetFolderNameRequest;
+import com.wnis.linkyway.dto.folder.SetFolderPathRequest;
+import com.wnis.linkyway.entity.Folder;
+import com.wnis.linkyway.entity.Member;
+import com.wnis.linkyway.repository.FolderRepository;
+import com.wnis.linkyway.repository.MemberRepository;
+import com.wnis.linkyway.security.testutils.WithMockMember;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.jdbc.Sql;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.MvcResult;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+import org.springframework.web.context.WebApplicationContext;
+import org.springframework.web.filter.CharacterEncodingFilter;
+
+import javax.transaction.Transactional;
+import java.util.Arrays;
+
+import static org.springframework.security.test.web.servlet.setup.SecurityMockMvcConfigurers.springSecurity;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@SpringBootTest
+@AutoConfigureMockMvc
+@Transactional
+@Sql("/sqltest/initialize-test.sql")
+public class FolderControllerIntegrationTest {
+    private final Logger logger = LoggerFactory.getLogger(TagControllerIntegrationTest.class);
+    @Autowired
+    WebApplicationContext ctx;
+    @Autowired
+    MemberRepository memberRepository;
+    @Autowired
+    FolderRepository folderRepository;
+    @Autowired
+    ObjectMapper objectMapper;
+    @Autowired
+    MockMvc mockMvc;
+    
+    @BeforeEach
+    void setup() {
+        //MockMvc 설정
+        mockMvc = MockMvcBuilders.webAppContextSetup(ctx)
+                .apply(springSecurity())
+                .addFilters(new CharacterEncodingFilter("UTF-8", true))  // 필터 추가
+                .alwaysDo(print())
+                .build();
+        
+        Member member1 = Member.builder()
+                .email("marrin1101@naver.com")
+                .nickname("Hyeon")
+                .password("A1!a1234")
+                .build();
+        
+        Folder folder1 = Folder.builder()
+                .member(member1)
+                .depth(1L)
+                .name("f1")
+                .build();
+        
+        Folder folder2 = Folder.builder()
+                .member(member1)
+                .name("f2")
+                .depth(2L)
+                .parent(folder1)
+                .build();
+        
+        Folder folder3 = Folder.builder()
+                .member(member1)
+                .name("f3")
+                .depth(3L)
+                .parent(folder2)
+                .build();
+        
+        Folder folder4 = Folder.builder()
+                .member(member1)
+                .name("f4")
+                .depth(3L)
+                .parent(folder2)
+                .build();
+        
+        Folder folder5 = Folder.builder()
+                .member(member1)
+                .name("f5")
+                .depth(2L)
+                .parent(folder1)
+                .build();
+        
+        memberRepository.save(member1);
+        folderRepository.saveAll(Arrays.asList(folder1, folder2, folder3, folder4, folder5));
+        
+    }
+    
+    @Nested
+    @DisplayName("폴더 조회")
+    class SearchFolder {
+        
+        @Test
+        @DisplayName("응답 테스트")
+        @WithMockMember(id = 1L, email = "marrin1101@naver.com")
+        void responseTest() throws Exception {
+            MvcResult mvcResult = mockMvc.perform(get("/api/folders/1"))
+                    .andExpect(status().is(200))
+                    .andReturn();
+            
+            logger.info(mvcResult.getResponse().getContentAsString());
+            
+        }
+    }
+    
+    @Nested
+    @DisplayName("Default 폴더 추가")
+    class AddSuperFolder {
+        
+        @Test
+        @DisplayName("응답 테스트")
+        @WithMockMember(id = 1L, email = "marrin1101@naver.com")
+        void responseTest() throws Exception {
+            MvcResult mvcResult = mockMvc.perform(post("/api/folders/super"))
+                    .andExpect(status().is(200))
+                    .andReturn();
+            
+            logger.info(mvcResult.getResponse().getContentAsString());
+        }
+    }
+    
+    @Nested
+    @DisplayName("폴더 추가")
+    class AddFolder {
+        
+        @Test
+        @DisplayName("응답 테스트")
+        @WithMockMember(id = 1L, email = "marrin1101@naver.com")
+        void responseTest() throws Exception {
+            AddFolderRequest addFolderRequest = AddFolderRequest.builder()
+                    .parentFolderId(1L)
+                    .name("f10")
+                    .build();
+            
+            MvcResult mvcResult = mockMvc.perform(post("/api/folders")
+                            .contentType("application/json")
+                            .content(objectMapper.writeValueAsBytes(addFolderRequest)))
+                    .andExpect(status().is(200))
+                    .andReturn();
+            
+            logger.info(mvcResult.getResponse().getContentAsString());
+            
+        }
+        
+        @Test
+        @DisplayName("멤버 없는 경우 응답 테스트")
+        @WithMockMember(id = 10L, email = "marrin1101@naver.com")
+        void NotExistMemberResponseTest() throws Exception {
+            AddFolderRequest addFolderRequest = AddFolderRequest.builder()
+                    .parentFolderId(1L)
+                    .name("f10")
+                    .build();
+            
+            MvcResult mvcResult = mockMvc.perform(post("/api/folders")
+                            .contentType("application/json")
+                            .content(objectMapper.writeValueAsBytes(addFolderRequest)))
+                    .andExpect(status().is(409))
+                    .andReturn();
+            
+            logger.info(mvcResult.getResponse().getContentAsString());
+            
+        }
+        
+        @Test
+        @DisplayName("부모 폴더가 없는 경우 응답 테스트")
+        @WithMockMember(id = 1L, email = "marrin1101@naver.com")
+        void NotExistFolderResponseTest() throws Exception {
+            AddFolderRequest addFolderRequest = AddFolderRequest.builder()
+                    .parentFolderId(100L)
+                    .name("f10")
+                    .build();
+            
+            MvcResult mvcResult = mockMvc.perform(post("/api/folders")
+                            .contentType("application/json")
+                            .content(objectMapper.writeValueAsBytes(addFolderRequest)))
+                    .andExpect(status().is(409))
+                    .andReturn();
+            
+            logger.info(mvcResult.getResponse().getContentAsString());
+            
+        }
+    }
+    
+    @Nested
+    @DisplayName("폴더 이름 수정")
+    class SetFolderNameTest {
+        
+        @Test
+        @DisplayName("응답 테스트")
+        @WithMockMember(id = 1L, email = "marrin1101@naver.com")
+        void responseTest() throws Exception {
+            SetFolderNameRequest setFolderNameRequest = SetFolderNameRequest.builder()
+                    .name("f_10L").build();
+            
+            MvcResult mvcResult = mockMvc.perform(put("/api/folders/1/name")
+                            .contentType("application/json")
+                            .content(objectMapper.writeValueAsString(setFolderNameRequest)))
+                    .andExpect(status().is(200))
+                    .andReturn();
+            
+            logger.info(mvcResult.getResponse().getContentAsString());
+        }
+        
+        @Test
+        @DisplayName("폴더가 존재하지 않는 경우 응답 테스트")
+        @WithMockMember(id = 1L, email = "marrin1101@naver.com")
+        void NotExistFolderResponseTest() throws Exception {
+            SetFolderNameRequest setFolderNameRequest = SetFolderNameRequest.builder()
+                    .name("f_10L").build();
+            
+            MvcResult mvcResult = mockMvc.perform(put("/api/folders/100/name")
+                            .contentType("application/json")
+                            .content(objectMapper.writeValueAsString(setFolderNameRequest)))
+                    .andExpect(status().is(409))
+                    .andReturn();
+            
+            logger.info(mvcResult.getResponse().getContentAsString());
+        }
+        
+    }
+    
+    @Nested
+    @DisplayName("폴더 경로 수정")
+    class SetFolderPathTest {
+        
+        @Test
+        @DisplayName("응답 테스트")
+        @WithMockMember(id = 1L, email = "marrin1101@naver.com")
+        void responseTest() throws Exception {
+            SetFolderPathRequest setFolderPathRequest = SetFolderPathRequest.builder()
+                    .targetFolderId(5L)
+                    .build();
+            
+            MvcResult mvcResult = mockMvc.perform(put("/api/folders/3/path")
+                            .contentType("application/json")
+                            .content(objectMapper.writeValueAsString(setFolderPathRequest)))
+                    .andExpect(status().is(200))
+                    .andReturn();
+            
+            logger.info(mvcResult.getResponse().getContentAsString());
+        }
+        
+        @Test
+        @DisplayName("수정하려는 폴더가 없는 경우 테스트")
+        @WithMockMember(id = 1L, email = "marrin1101@naver.com")
+        void NotExistOriginFolderTest() throws Exception {
+            SetFolderPathRequest setFolderPathRequest = SetFolderPathRequest.builder()
+                    .targetFolderId(5L)
+                    .build();
+            
+            MvcResult mvcResult = mockMvc.perform(put("/api/folders/101/path")
+                            .contentType("application/json")
+                            .content(objectMapper.writeValueAsString(setFolderPathRequest)))
+                    .andExpect(status().is(409))
+                    .andReturn();
+            
+            logger.info(mvcResult.getResponse().getContentAsString());
+        }
+        
+        @Test
+        @DisplayName("목표 부모 폴더가 없는 경우 테스트")
+        @WithMockMember(id = 1L, email = "marrin1101@naver.com")
+        void NotExistTargetFolderTest() throws Exception {
+            SetFolderPathRequest setFolderPathRequest = SetFolderPathRequest.builder()
+                    .targetFolderId(100L)
+                    .build();
+            
+            MvcResult mvcResult = mockMvc.perform(put("/api/folders/1/path")
+                            .contentType("application/json")
+                            .content(objectMapper.writeValueAsString(setFolderPathRequest)))
+                    .andExpect(status().is(409))
+                    .andReturn();
+            
+            logger.info(mvcResult.getResponse().getContentAsString());
+        }
+        
+        @Test
+        @DisplayName("목표부모가 직계후손인 경우 테스트")
+        @WithMockMember(id = 1L, email = "marrin1101@naver.com")
+        void TargetFolderIsDirectDescendantFolderTest() throws Exception {
+            SetFolderPathRequest setFolderPathRequest = SetFolderPathRequest.builder()
+                    .targetFolderId(3L)
+                    .build();
+            
+            MvcResult mvcResult = mockMvc.perform(put("/api/folders/1/path")
+                            .contentType("application/json")
+                            .content(objectMapper.writeValueAsString(setFolderPathRequest)))
+                    .andExpect(status().is(409))
+                    .andReturn();
+            
+            logger.info(mvcResult.getResponse().getContentAsString());
+        }
+    }
+    
+    @Nested
+    @DisplayName("삭제 테스트")
+    class DeleteFolderTest {
+        
+        @Test
+        @DisplayName("응답 테스트")
+        @WithMockMember(id = 1L, email = "marrin1101@naver.com")
+        void responseTest() throws Exception {
+            MvcResult mvcResult = mockMvc.perform(delete("/api/folders/1")
+                    )
+                    .andExpect(status().is(200))
+                    .andReturn();
+            
+            logger.info(mvcResult.getResponse().getContentAsString());
+        }
+        
+        @Test
+        @DisplayName("삭제할 폴더가 없는 경우 응답 테스트")
+        @WithMockMember(id = 1L, email = "marrin1101@naver.com")
+        void NotExistFolderResponseTest() throws Exception {
+            MvcResult mvcResult = mockMvc.perform(delete("/api/folders/100")
+                    )
+                    .andExpect(status().is(409))
+                    .andReturn();
+            
+            logger.info(mvcResult.getResponse().getContentAsString());
+        }
+    }
+}

--- a/src/test/java/com/wnis/linkyway/controller/folder/FolderControllerTest.java
+++ b/src/test/java/com/wnis/linkyway/controller/folder/FolderControllerTest.java
@@ -1,0 +1,128 @@
+package com.wnis.linkyway.controller.folder;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.wnis.linkyway.dto.folder.AddFolderRequest;
+import com.wnis.linkyway.dto.folder.SetFolderNameRequest;
+import com.wnis.linkyway.dto.folder.SetFolderPathRequest;
+import com.wnis.linkyway.security.testutils.WithMockMember;
+import com.wnis.linkyway.service.folder.FolderService;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+import org.springframework.web.context.WebApplicationContext;
+
+import static org.springframework.security.test.web.servlet.setup.SecurityMockMvcConfigurers.springSecurity;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+
+@SpringBootTest
+@AutoConfigureMockMvc
+class FolderControllerTest {
+    private final static Logger logger = LoggerFactory.getLogger(FolderControllerTest.class);
+    
+    @MockBean
+    private FolderService folderService;
+    
+    @Autowired
+    private ObjectMapper objectMapper;
+    
+    @Autowired
+    private WebApplicationContext context;
+    
+    @Autowired
+    private MockMvc mockMvc;
+    
+    @BeforeEach
+    private void setupMock() {
+        mockMvc =
+                MockMvcBuilders
+                        .webAppContextSetup(context)
+                        .apply(springSecurity())
+                        .alwaysDo(print())
+                        .build();
+    }
+    
+    @Nested
+    @DisplayName("HttpRequest 테스트")
+    class HttpRequestTest {
+        
+        @Test
+        @DisplayName("성공 테스트")
+        @WithMockMember(id = 1L)
+        void successTest() throws Exception {
+            AddFolderRequest addFolderRequest = AddFolderRequest.builder()
+                    .parentFolderId(1L)
+                    .name("hello").build();
+            
+            mockMvc.perform(post("/api/folders")
+                            .contentType("application/json")
+                            .content(objectMapper.writeValueAsString(addFolderRequest)))
+                    .andExpect(status().isOk());
+        }
+        
+        @Test
+        @DisplayName("post 요청 시 body 가 없는 경우 테스트")
+        @WithMockMember
+        void noBodyTest() throws Exception {
+            mockMvc.perform(post("/api/folders")
+                            .contentType("application/json")
+                    )
+                    .andExpect(status().is(400));
+        }
+    }
+    
+    @Nested
+    @DisplayName("Validation 예외 핸들러")
+    class ValidationExceptionHandlerTest {
+        
+        @Test
+        @DisplayName("addFolder 테스트")
+        @WithMockMember
+        void addFolderTest() throws Exception {
+            AddFolderRequest addFolderRequest = AddFolderRequest.builder()
+                    .build();
+            
+            mockMvc.perform(post("/api/folders")
+                            .contentType("application/json")
+                            .content(objectMapper.writeValueAsString(addFolderRequest)))
+                    .andExpect(status().is(400));
+        }
+        
+        @Test
+        @DisplayName("setFolderName 테스트")
+        @WithMockMember
+        void setFolderNameTest() throws Exception {
+            SetFolderNameRequest setFolderNameRequest = SetFolderNameRequest.builder()
+                    .build();
+            
+            mockMvc.perform(post("/api/folders")
+                            .contentType("application/json")
+                            .content(objectMapper.writeValueAsString(setFolderNameRequest)))
+                    .andExpect(status().is(400));
+        }
+        
+        @Test
+        @DisplayName("setFolderName 테스트")
+        @WithMockMember
+        void setFolderPathTest() throws Exception {
+            SetFolderPathRequest setFolderPathRequest = SetFolderPathRequest.builder()
+                    .build();
+            
+            mockMvc.perform(post("/api/folders")
+                            .contentType("application/json")
+                            .content(objectMapper.writeValueAsString(setFolderPathRequest)))
+                    .andExpect(status().is(400));
+        }
+    }
+}

--- a/src/test/java/com/wnis/linkyway/controller/tag/TagControllerIntegrationTest.java
+++ b/src/test/java/com/wnis/linkyway/controller/tag/TagControllerIntegrationTest.java
@@ -1,0 +1,223 @@
+package com.wnis.linkyway.controller.tag;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.wnis.linkyway.dto.Response;
+import com.wnis.linkyway.dto.tag.TagRequest;
+import com.wnis.linkyway.entity.Member;
+import com.wnis.linkyway.entity.Tag;
+import com.wnis.linkyway.repository.MemberRepository;
+import com.wnis.linkyway.repository.TagRepository;
+import com.wnis.linkyway.security.testutils.WithMockMember;
+import com.wnis.linkyway.service.tag.TagService;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.test.context.jdbc.Sql;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.MvcResult;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+import org.springframework.web.context.WebApplicationContext;
+import org.springframework.web.filter.CharacterEncodingFilter;
+
+import javax.transaction.Transactional;
+import java.util.Arrays;
+
+import static org.springframework.security.test.web.servlet.setup.SecurityMockMvcConfigurers.springSecurity;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@SpringBootTest
+@AutoConfigureMockMvc
+@Transactional
+@Sql("/sqltest/initialize-test.sql")
+public class TagControllerIntegrationTest {
+    
+    private final Logger logger = LoggerFactory.getLogger(TagControllerIntegrationTest.class);
+    @Autowired
+    WebApplicationContext ctx;
+    @Autowired
+    MemberRepository memberRepository;
+    @Autowired
+    TagRepository tagRepository;
+    @Autowired
+    TagService tagService;
+    @Autowired
+    ObjectMapper objectMapper;
+    @Autowired
+    MockMvc mockMvc;
+    
+    @BeforeEach
+    void setup() {
+        
+        //MockMvc 설정
+        mockMvc = MockMvcBuilders.webAppContextSetup(ctx)
+                .apply(springSecurity())
+                .addFilters(new CharacterEncodingFilter("UTF-8", true))  // 필터 추가
+                .alwaysDo(print())
+                .build();
+        
+        Member member = Member.builder()
+                .email("marrin1101@naver.com")
+                .nickname("Hyeon")
+                .password("A1!a1234")
+                .build();
+        
+        Tag tag1 = Tag.builder()
+                .name("Spring")
+                .shareable(true)
+                .views(0)
+                .build();
+        
+        Tag tag2 = Tag.builder()
+                .name("food1")
+                .shareable(false)
+                .views(10)
+                .build();
+        
+        member.addTag(tag1).addTag(tag2);
+        tagRepository.saveAll(Arrays.asList(tag1, tag2));
+        memberRepository.save(member);
+    }
+    
+    @Nested
+    @DisplayName("태그 조회")
+    class SearchTagsTest {
+        
+        @Test
+        @DisplayName("태그 조회 Response")
+        @WithMockMember(id = 1, email = "marrin1101@naver.com")
+        void responseTest() throws Exception {
+            Response response = tagService.searchTags(1L);
+            ResponseEntity<Response> expected = ResponseEntity.ok(response);
+            
+            MvcResult mvcResult = mockMvc.perform(get("/api/tags/table"))
+                    .andExpect(status().is(200))
+                    .andReturn();
+            
+            String s = mvcResult.getResponse().getContentAsString();
+            logger.info(s);
+            
+        }
+    }
+    
+    @Nested
+    @DisplayName("태그 추가")
+    class AddTagTest {
+        
+        @Test
+        @DisplayName("태그 추가 Response")
+        @WithMockMember(id = 1, email = "marrin1101@naver.com")
+        void ResponseTest() throws Exception {
+            TagRequest tagRequest = TagRequest.builder()
+                    .tagName("hello")
+                    .shareable("true")
+                    .build();
+            MvcResult mvcResult = mockMvc.perform(post("/api/tags")
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content(objectMapper.writeValueAsString(tagRequest)))
+                    .andExpect(status().isOk())
+                    .andReturn();
+            String res = mvcResult.getResponse().getContentAsString();
+            logger.info(res);
+            
+        }
+        
+        @Test
+        @DisplayName("중복시 핸들러 Response")
+        @WithMockMember(id = 1, email = "marrin1101@naver.com")
+        void ResponseExceptionTest() throws Exception {
+            TagRequest tagRequest = TagRequest.builder()
+                    .tagName("Spring")
+                    .shareable("true")
+                    .build();
+            
+            MvcResult mvcResult = mockMvc.perform(post("/api/tags")
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content(objectMapper.writeValueAsString(tagRequest)))
+                    .andExpect(status().is(409))
+                    .andReturn();
+            
+            logger.info(mvcResult.getResponse().getContentAsString());
+        }
+    }
+    
+    @Nested
+    @DisplayName("태그 수정")
+    
+    class SetTag {
+        
+        @Test
+        @DisplayName("수정 Response")
+        @WithMockMember(id = 1, email = "marrin1101@naver.com")
+        void responseTest() throws Exception {
+            TagRequest tagRequest = TagRequest.builder()
+                    .tagName("Summer")
+                    .shareable("false")
+                    .build();
+            
+            MvcResult mvcResult = mockMvc.perform(put("/api/tags/1")
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content(objectMapper.writeValueAsString(tagRequest)))
+                    .andExpect(status().is(200))
+                    .andReturn();
+            
+            logger.info(mvcResult.getResponse().getContentAsString());
+        }
+        
+        @Test
+        @DisplayName("없는데 수정 예외 핸들러")
+        @WithMockMember(id = 1, email = "marrin1101@naver.com")
+        void responseExceptionTest() throws Exception {
+            TagRequest tagRequest = TagRequest.builder()
+                    .tagName("Summer")
+                    .shareable("false")
+                    .build();
+            
+            MvcResult mvcResult = mockMvc.perform(put("/api/tags/4")
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content(objectMapper.writeValueAsString(tagRequest)))
+                    .andExpect(status().is(409))
+                    .andReturn();
+            
+            logger.info(mvcResult.getResponse().getContentAsString());
+        }
+    }
+    
+    @Nested
+    @DisplayName("태그 삭제")
+    class DeleteTag {
+        
+        @DisplayName("삭제 Response")
+        @Test
+        @WithMockMember(id = 1, email = "marrin1101@naver.com")
+        void responseTest() throws Exception {
+            MvcResult mvcResult = mockMvc.perform(delete("/api/tags/1")
+                    )
+                    .andExpect(status().is(200))
+                    .andReturn();
+            
+            logger.info(mvcResult.getResponse().getContentAsString());
+        }
+        
+        @DisplayName("없는데 삭제 예외 핸들러")
+        @Test
+        @WithMockMember(id = 1, email = "marrin1101@naver.com")
+        void responseExceptionTest() throws Exception {
+            MvcResult mvcResult = mockMvc.perform(delete("/api/tags/5")
+                    )
+                    .andExpect(status().is(409))
+                    .andReturn();
+            
+            logger.info(mvcResult.getResponse().getContentAsString());
+        }
+    }
+}

--- a/src/test/java/com/wnis/linkyway/controller/tag/TagControllerTest.java
+++ b/src/test/java/com/wnis/linkyway/controller/tag/TagControllerTest.java
@@ -1,0 +1,135 @@
+package com.wnis.linkyway.controller.tag;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.wnis.linkyway.dto.tag.TagRequest;
+import com.wnis.linkyway.exception.error.ErrorResponse;
+import com.wnis.linkyway.repository.MemberRepository;
+import com.wnis.linkyway.security.testutils.WithMockMember;
+import com.wnis.linkyway.service.tag.TagService;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.MvcResult;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+import org.springframework.web.context.WebApplicationContext;
+
+import javax.transaction.Transactional;
+
+import static com.wnis.linkyway.utils.ResponseBodyMatchers.responseBody;
+import static org.springframework.security.test.web.servlet.setup.SecurityMockMvcConfigurers.springSecurity;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@SpringBootTest
+@Transactional
+@AutoConfigureMockMvc
+class TagControllerTest {
+    
+    private final static Logger logger = LoggerFactory.getLogger(TagControllerTest.class);
+    
+    @MockBean
+    private TagService tagService;
+    
+    @Autowired
+    private ObjectMapper objectMapper;
+    
+    @Autowired
+    private MemberRepository memberRepository;
+    
+    @Autowired
+    private WebApplicationContext context;
+    
+    @Autowired
+    private MockMvc mockMvc;
+    
+    @BeforeEach
+    private void before() {
+        mockMvc =
+                MockMvcBuilders
+                        .webAppContextSetup(context)
+                        .apply(springSecurity())
+                        .alwaysDo(print())
+                        .build();
+    }
+    
+    
+    @Nested
+    @DisplayName("1. HttpRequest 테스트")
+    class HttpRequestTest {
+        
+        @Test
+        @DisplayName("HttpRequest 성공 테스트")
+        @WithMockMember(id = 1L)
+        void httpRequestSuccessTest() throws Exception {
+            TagRequest tagRequest = TagRequest.builder().tagName("스프링").shareable("true").build();
+            
+            mockMvc.perform(post("/api/tags").contentType("application/json").content(objectMapper.writeValueAsString(tagRequest))).andExpect(status().isOk());
+        }
+        
+        @Test
+        @DisplayName("post 요청 시 HttpRequest 바디가 없는 경우 테스트")
+        void httpRequestFail_NoBodyCaseTest() throws Exception {
+            TagRequest tagRequest = TagRequest.builder().tagName("스프링").shareable("true").build();
+            
+            mockMvc.perform(post("/api/tags").contentType("application/json")).andExpect(status().is(400));
+            
+        }
+        
+        @Test
+        @DisplayName("HttpRequest Http Method를 잘못 요청한 경우 테스트")
+        void httpRequestFail_IllegalHttpMethodCaseTest() throws Exception {
+            TagRequest tagRequest = TagRequest.builder().tagName("스프링").shareable("true").build();
+            
+            mockMvc.perform(put("/api/tags").contentType("application/json")).andExpect(status().is(405));
+        }
+        
+        @Test
+        @DisplayName("HttpRequest Mapping하지 않는 URI가 들어온 경우 테스트")
+        void httpRequestFail_NotFoundCaseTest() throws Exception {
+            MvcResult ret = mockMvc.perform(post("/apia/tags").contentType("application/json"))
+                    .andExpect(status().is(404))
+                    .andReturn();
+            
+        }
+    }
+    
+    @Nested
+    @DisplayName("2. Validation 테스트")
+    class ValidationTest {
+        @ParameterizedTest
+        @CsvSource(value = {"'', ''", "tagName, ''", "' ', shreable"})
+        @DisplayName("빈 값 테스트")
+        void nullTest(String tagName, String shareable) throws Exception {
+            TagRequest tagRequest = TagRequest.builder().tagName(tagName).shareable(shareable).build();
+            
+            MvcResult mvcResult = mockMvc.perform(post("/api/tags").contentType("application/json").content(objectMapper.writeValueAsString(tagRequest))).andExpect(status().is(400)).andExpect(responseBody().containsPropertiesAsJson(ErrorResponse.class)) // body의
+                    .andReturn();
+            
+        }
+        
+        @ParameterizedTest
+        @CsvSource(value = {"'aa', ' '", "aa, 'true1'", "'aa', false2"})
+        @DisplayName("패턴 테스트")
+        void patternTest(String tagName, String shareable) throws Exception {
+            TagRequest tagRequest = TagRequest.builder().tagName(tagName).shareable(shareable).build();
+            
+            MvcResult mvcResult = mockMvc.perform(post("/api/tags").contentType("application/json").content(objectMapper.writeValueAsString(tagRequest))).andExpect(status().is(400)).andExpect(responseBody().containsPropertiesAsJson(ErrorResponse.class)) // body의
+                    .andReturn();
+            
+        }
+    }
+    
+    
+}

--- a/src/test/java/com/wnis/linkyway/dto/folder/AddFolderRequestTest.java
+++ b/src/test/java/com/wnis/linkyway/dto/folder/AddFolderRequestTest.java
@@ -1,0 +1,83 @@
+package com.wnis.linkyway.dto.folder;
+
+import com.wnis.linkyway.validation.ValidationGroup;
+import org.hibernate.validator.internal.engine.ConstraintViolationImpl;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import javax.validation.ConstraintViolation;
+import javax.validation.Validation;
+import javax.validation.Validator;
+import javax.validation.ValidatorFactory;
+import java.util.Set;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+
+class AddFolderRequestTest {
+    
+    private static Validator validator;
+    private static ValidatorFactory factory;
+    private final Logger logger = LoggerFactory.getLogger(AddFolderRequestTest.class);
+    
+    @BeforeAll
+    static void setup() {
+        factory = Validation.buildDefaultValidatorFactory();
+        validator = factory.getValidator();
+    }
+    
+    @AfterAll
+    static void close() {
+        factory.close();
+    }
+    
+    @Test
+    @DisplayName("Not Blank 테스트")
+    void notBlankTest() {
+        AddFolderRequest addFolderRequest = AddFolderRequest.builder()
+                .build();
+        
+        Set<ConstraintViolation<AddFolderRequest>> constraintViolations = validator
+                .validate(addFolderRequest, ValidationGroup.NotBlankGroup.class);
+        
+        constraintViolations.forEach((e) -> {
+            logger.info(e.getMessage());
+            assertThat(e).isInstanceOf(ConstraintViolationImpl.class);
+        });
+    }
+    
+    @Test
+    @DisplayName("Pattern 테스트")
+    void patternTest() {
+        AddFolderRequest addFolderRequest = AddFolderRequest.builder()
+                .parentFolderId(0L)
+                .name("가@")
+                .build();
+        
+        Set<ConstraintViolation<AddFolderRequest>> constraintViolations = validator
+                .validate(addFolderRequest, ValidationGroup.PatternCheckGroup.class);
+        
+        constraintViolations.forEach((e) -> {
+            logger.info(e.getMessage());
+            assertThat(e).isInstanceOf(ConstraintViolationImpl.class);
+        });
+    }
+    
+    @Test
+    @DisplayName("통과 테스트")
+    void successTest() {
+        AddFolderRequest addFolderRequest = AddFolderRequest.builder()
+                .parentFolderId(0L)
+                .name("가")
+                .build();
+        
+        Set<ConstraintViolation<AddFolderRequest>> constraintViolations = validator
+                .validate(addFolderRequest, ValidationGroup.PatternCheckGroup.class);
+        
+        assertThat(constraintViolations).isEmpty();
+    }
+}

--- a/src/test/java/com/wnis/linkyway/dto/folder/SetFolderNameRequestTest.java
+++ b/src/test/java/com/wnis/linkyway/dto/folder/SetFolderNameRequestTest.java
@@ -1,0 +1,81 @@
+package com.wnis.linkyway.dto.folder;
+
+import com.wnis.linkyway.validation.ValidationGroup;
+import org.hibernate.validator.internal.engine.ConstraintViolationImpl;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import javax.validation.ConstraintViolation;
+import javax.validation.Validation;
+import javax.validation.Validator;
+import javax.validation.ValidatorFactory;
+import java.util.Set;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class SetFolderNameRequestTest {
+    
+    private static Validator validator;
+    private static ValidatorFactory factory;
+    private final Logger logger = LoggerFactory.getLogger(SetFolderNameRequestTest.class);
+    
+    @BeforeAll
+    static void setup() {
+        factory = Validation.buildDefaultValidatorFactory();
+        validator = factory.getValidator();
+    }
+    
+    @AfterAll
+    static void close() {
+        factory.close();
+    }
+    
+    @Test
+    @DisplayName("Not Blank 테스트")
+    void notBlankTest() {
+        SetFolderNameRequest setFolderNameRequest = SetFolderNameRequest.builder()
+                .build();
+        
+        Set<ConstraintViolation<SetFolderNameRequest>> constraintViolations = validator
+                .validate(setFolderNameRequest, ValidationGroup.NotBlankGroup.class);
+        
+        constraintViolations.forEach((e) -> {
+            logger.info(e.getMessage());
+            assertThat(e).isInstanceOf(ConstraintViolationImpl.class);
+        });
+    }
+    
+    @Test
+    @DisplayName("Pattern 테스트")
+    void patternTest() {
+        SetFolderNameRequest setFolderNameRequest = SetFolderNameRequest.builder()
+                .name("가")
+                .build();
+        
+        Set<ConstraintViolation<SetFolderNameRequest>> constraintViolations = validator
+                .validate(setFolderNameRequest, ValidationGroup.NotBlankGroup.class);
+        
+        constraintViolations.forEach((e) -> {
+            logger.info(e.getMessage());
+            assertThat(e).isInstanceOf(ConstraintViolationImpl.class);
+        });
+    }
+    
+    @Test
+    @DisplayName("통과 테스트")
+    void successTest() {
+        AddFolderRequest addFolderRequest = AddFolderRequest.builder()
+                .parentFolderId(0L)
+                .name("가")
+                .build();
+        
+        Set<ConstraintViolation<AddFolderRequest>> constraintViolations = validator
+                .validate(addFolderRequest, ValidationGroup.PatternCheckGroup.class);
+        
+        assertThat(constraintViolations).isEmpty();
+    }
+}

--- a/src/test/java/com/wnis/linkyway/dto/folder/SetFolderPathRequestTest.java
+++ b/src/test/java/com/wnis/linkyway/dto/folder/SetFolderPathRequestTest.java
@@ -1,0 +1,78 @@
+package com.wnis.linkyway.dto.folder;
+
+import com.wnis.linkyway.validation.ValidationGroup;
+import org.hibernate.validator.internal.engine.ConstraintViolationImpl;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import javax.validation.ConstraintViolation;
+import javax.validation.Validation;
+import javax.validation.Validator;
+import javax.validation.ValidatorFactory;
+import java.util.Set;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class SetFolderPathRequestTest {
+    private static Validator validator;
+    private static ValidatorFactory factory;
+    private final Logger logger = LoggerFactory.getLogger(SetFolderPathRequestTest.class);
+    
+    @BeforeAll
+    static void setup() {
+        factory = Validation.buildDefaultValidatorFactory();
+        validator = factory.getValidator();
+    }
+    
+    @AfterAll
+    static void close() {
+        factory.close();
+    }
+    
+    @Test
+    @DisplayName("Not Blank 테스트")
+    void notBlankTest() {
+        SetFolderPathRequest setFolderPathRequest = SetFolderPathRequest.builder()
+                .build();
+        
+        Set<ConstraintViolation<SetFolderPathRequest>> constraintViolations = validator
+                .validate(setFolderPathRequest, ValidationGroup.NotBlankGroup.class);
+        
+        constraintViolations.forEach((e) -> {
+            logger.info(e.getMessage());
+            assertThat(e).isInstanceOf(ConstraintViolationImpl.class);
+        });
+    }
+    
+    @Test
+    @DisplayName("positive 테스트")
+    void positiveTest() {
+        SetFolderPathRequest setFolderPathRequest = SetFolderPathRequest.builder()
+                .targetFolderId(-1L)
+                .build();
+        
+        Set<ConstraintViolation<SetFolderPathRequest>> constraintViolations = validator
+                .validate(setFolderPathRequest);
+        
+        constraintViolations.forEach((e) -> {
+            logger.info(e.getMessage());
+            assertThat(e).isInstanceOf(ConstraintViolationImpl.class);
+        });
+    }
+    
+    @Test
+    @DisplayName("통과 테스트")
+    void successTest() {
+        SetFolderPathRequest setFolderPathRequest = SetFolderPathRequest.builder()
+                .targetFolderId(1L)
+                .build();
+        
+        Set<ConstraintViolation<SetFolderPathRequest>> constraintViolations = validator
+                .validate(setFolderPathRequest);
+        assertThat(constraintViolations).isEmpty();
+    }
+}

--- a/src/test/java/com/wnis/linkyway/repository/FolderRepositoryTest.java
+++ b/src/test/java/com/wnis/linkyway/repository/FolderRepositoryTest.java
@@ -1,0 +1,212 @@
+package com.wnis.linkyway.repository;
+
+import com.wnis.linkyway.entity.Folder;
+import com.wnis.linkyway.entity.Member;
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.test.context.jdbc.Sql;
+
+import javax.persistence.EntityManager;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Objects;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@DataJpaTest
+@AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
+@Sql("/sqltest/initialize-test.sql")
+class FolderRepositoryTest {
+    
+    @Autowired
+    FolderRepository folderRepository;
+    @Autowired
+    MemberRepository memberRepository;
+    @Autowired
+    EntityManager entityManager;
+    private final Logger logger = LoggerFactory.getLogger(FolderRepositoryTest.class);
+    
+    @BeforeEach
+    void setup() {
+        
+        Member member1 = Member.builder()
+                .email("maee@naver.com")
+                .nickname("sssee")
+                .password("a!aA212341")
+                .build();
+        
+        
+        Folder folder1 = Folder.builder()
+                .member(member1)
+                .name("f1")
+                .build();
+        
+        Folder folder2 = Folder.builder()
+                .member(member1)
+                .name("f2")
+                .parent(folder1)
+                .build();
+        
+        Folder folder3 = Folder.builder()
+                .member(member1)
+                .name("f3")
+                .parent(folder2)
+                .build();
+        
+        Folder folder4 = Folder.builder()
+                .member(member1)
+                .name("f4")
+                .parent(folder2)
+                .build();
+        
+        Folder folder6 = Folder.builder()
+                .member(member1)
+                .name("f6")
+                .parent(folder1)
+                .build();
+        
+        memberRepository.save(member1);
+        folderRepository.saveAll(Arrays.asList(folder1, folder2, folder3, folder4, folder6));
+    }
+    
+    @Test
+    @DisplayName("findFolderByMemberId 테스트")
+    void findFolderByMemberIdTest() {
+        List<Folder> folders = folderRepository.findFoldersByMemberId(1L);
+        folders.forEach((f) -> logger.info("폴더 id = {}, 폴더 이름 = {}, 폴더 부모 = {}, 폴더 자식 = {}",
+                f.getId(), f.getName(), f.getParent(), f.getChildren()));
+        assertThat(folders.get(1)).isInstanceOfSatisfying(Folder.class, f -> {
+            assertThat(f.getId()).isEqualTo(2);
+            assertThat(f.getName()).isEqualTo("f2");
+            assertThat(f.getParent().getId()).isEqualTo(1);
+            assertThat(f.getChildren().size()).isEqualTo(2);
+        });
+        
+    }
+    
+    @Test
+    @DisplayName("findFolderByFolderId 테스트")
+    void findFolderByIdTest() {
+        Folder folder = folderRepository.findFolderById(2L);
+        logger.info("폴더 id = {}, 폴더 이름 = {}, 폴더 부모 = {}, 폴더 자식 = {}",
+                folder.getId(), folder.getName(), folder.getParent(), folder.getChildren());
+        
+        assertThat(folder).isInstanceOfSatisfying(Folder.class, (f) -> {
+            assertThat(f.getId()).isEqualTo(2);
+            assertThat(f.getName()).isEqualTo("f2");
+            assertThat(f.getParent().getId()).isEqualTo(1);
+            assertThat(f.getChildren().size()).isEqualTo(2);
+        });
+    }
+    
+    @Test
+    @DisplayName("폴더 추가 테스트")
+    void insertFolder() {
+        Folder parent = folderRepository.findFolderById(1L);
+        assertThat(parent.getChildren().size()).isEqualTo(2);
+        
+        Folder newFolder = Folder.builder()
+                .parent(parent)
+                .name("f5")
+                .build();
+        
+        
+        folderRepository.save(newFolder);
+//        folderRepository.save(parent);
+        folderRepository.flush();
+        entityManager.clear();
+        
+        parent = folderRepository.findFolderById(1L);
+        assertThat(parent.getChildren().size()).isEqualTo(3);
+    }
+    
+    @Test
+    @DisplayName("폴더 경로 수정 테스트")
+    void modifyMyParent() {
+        entityManager.clear();
+        
+        Folder folder2 = folderRepository.findFolderById(2L);
+        Folder folder6 = folderRepository.findFolderById(5L);
+        
+        
+        folder2.modifyParent(folder6);
+        
+        // 트랜잭션 전에 DB로 바로 flush
+        folderRepository.saveAndFlush(folder2);
+//        folderRepository.saveAndFlush(folder6);
+        
+        // 영속성 컨테이너가 깨끗한 상태에서 DB에 수정이 반영되었는지 테스트
+        entityManager.clear();
+        
+        Folder newFolder1 = folderRepository.findFolderById(1L);
+        Folder newFolder2 = folderRepository.findFolderById(2L);
+        Folder newFolder6 = folderRepository.findFolderById(5L);
+        
+        logger.info("폴더2 부모 이름: {}", newFolder2.getParent().getName());
+        logger.info("폴더6 자식 이름: {}", newFolder6.getChildren().get(newFolder6.getChildren().size() - 1).getName());
+        logger.info("폴더1 자식 이름: {}", newFolder1.getChildren().get(0).getName());
+        
+        assertThat(newFolder2.getParent().getName()).isEqualTo("f6");
+        assertThat(newFolder6.getChildren().get(0).getId()).isEqualTo(2L);
+        
+    }
+    
+    @Test
+    @DisplayName("폴더 경로 수정 실패 테스트")
+    void failModifyMyParent() {
+        entityManager.clear();
+        
+        Folder folder2 = folderRepository.findFolderById(2L);
+        Folder folder4 = folderRepository.findFolderById(4L);
+        
+        Assertions.assertThatThrownBy(() -> folder2.modifyParent(folder4)).isInstanceOf(IllegalStateException.class);
+        
+    }
+    
+    @Test
+    @DisplayName("폴더 이름 수정 테스트")
+    void modifyFolderName() {
+        Folder folder = folderRepository.findFolderById(1L);
+        folder.updateName("hello");
+        folderRepository.saveAndFlush(folder);
+        entityManager.clear();
+        
+        Folder newFolder = folderRepository.findFolderById(1L);
+        assertThat(newFolder.getName()).isEqualTo("hello");
+    }
+    
+    @Test
+    @DisplayName("회원가입시 기본 폴더 생성 테스트")
+    void addSuperFolder() {
+        folderRepository.addSuperFolder(1L);
+        List<Folder> folders = folderRepository.findFoldersByMemberId(1L);
+        folders.forEach((f) -> logger.info("폴더 이름: {}, 폴더 부모 id: {}", f.getName(), f.getParent()));
+        assertThat(folders.get(5).getParent()).isNull();
+    }
+    
+    @Test
+    @DisplayName("폴더 삭제 테스트")
+    void deleteFolders() {
+        // cascade remove: 부모 객체가 날라가면 자식 객체 또한 날려버린다.
+        // 현재 객체가 날라간다고 부모객체를 날리진 않는다. 테스트 완료
+        folderRepository.deleteById(2L);
+        folderRepository.flush();
+        entityManager.clear();
+        
+        Folder folder3 = folderRepository.findById(3L).orElse(null);
+        
+        assertThat(folder3).isNull();
+        assertThat(memberRepository.findById(1L).orElse(null)).isNotNull();
+        
+        Folder folder1 = folderRepository.findById(1L).orElse(null);
+        assertThat(Objects.requireNonNull(folder1).getMember()).isNotNull();
+    }
+    
+}

--- a/src/test/java/com/wnis/linkyway/service/folder/FolderServiceImplTest.java
+++ b/src/test/java/com/wnis/linkyway/service/folder/FolderServiceImplTest.java
@@ -1,0 +1,264 @@
+package com.wnis.linkyway.service.folder;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.wnis.linkyway.dto.Response;
+import com.wnis.linkyway.dto.folder.AddFolderRequest;
+import com.wnis.linkyway.dto.folder.FolderResponse;
+import com.wnis.linkyway.dto.folder.SetFolderNameRequest;
+import com.wnis.linkyway.dto.folder.SetFolderPathRequest;
+import com.wnis.linkyway.entity.Folder;
+import com.wnis.linkyway.entity.Member;
+import com.wnis.linkyway.exception.common.ResourceConflictException;
+import com.wnis.linkyway.repository.FolderRepository;
+import com.wnis.linkyway.repository.MemberRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.test.context.jdbc.Sql;
+
+import java.util.Arrays;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+@DataJpaTest
+@AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
+@Sql("/sqltest/initialize-test.sql")
+@Import({FolderServiceImpl.class, ObjectMapper.class})
+class FolderServiceImplTest {
+    
+    @Autowired
+    FolderService folderService;
+    @Autowired
+    FolderRepository folderRepository;
+    @Autowired
+    MemberRepository memberRepository;
+    @Autowired
+    ObjectMapper objectMapper;
+    private final Logger logger = LoggerFactory.getLogger(FolderServiceImplTest.class);
+    
+    @BeforeEach
+    void setup() {
+        
+        Member member1 = Member.builder()
+                .email("maee@naver.com")
+                .nickname("serin")
+                .password("a!aA212341")
+                .build();
+        
+        
+        Folder folder1 = Folder.builder()
+                .member(member1)
+                .name("f1")
+                .depth(1L)
+                .build();
+        
+        Folder folder2 = Folder.builder()
+                .member(member1)
+                .name("f2")
+                .depth(2L)
+                .parent(folder1)
+                .build();
+        
+        Folder folder3 = Folder.builder()
+                .member(member1)
+                .name("f3")
+                .depth(3L)
+                .parent(folder2)
+                .build();
+        
+        Folder folder4 = Folder.builder()
+                .member(member1)
+                .name("f4")
+                .depth(3L)
+                .parent(folder2)
+                .build();
+        
+        Folder folder6 = Folder.builder()
+                .member(member1)
+                .name("f6")
+                .depth(2L)
+                .parent(folder1)
+                .build();
+        
+        memberRepository.save(member1);
+        folderRepository.saveAll(Arrays.asList(folder1, folder2, folder3, folder4, folder6));
+    }
+    
+    
+    @Nested
+    @DisplayName("폴더 조회")
+    class FindFolderTest {
+        
+        @Test
+        @DisplayName("응답 테스트")
+        void Test() throws JsonProcessingException {
+            Response<FolderResponse> folder = folderService.findFolder(1L);
+            String s = objectMapper.writeValueAsString(folder);
+            logger.info(s);
+        }
+        
+        @Test
+        @DisplayName("핸들링 테스트")
+        void exceptionTest() {
+            
+            assertThatThrownBy(() -> folderService.findFolder(30L)).isInstanceOf(ResourceConflictException.class);
+            
+        }
+        
+    }
+    
+    @Nested
+    @DisplayName("Default 폴더 추가")
+    class AddSuperFolderTest {
+        
+        @Test
+        @DisplayName("응답 테스트")
+        void responseTest() throws JsonProcessingException {
+            Response<FolderResponse> response = folderService.addSuperFolder(1L);
+            List<Folder> folders = folderRepository.findFoldersByMemberId(1L);
+            folders.forEach((f) -> logger.info("폴더 이름: {}", f.getName()));
+            
+            logger.info(objectMapper.writeValueAsString(response));
+        }
+    }
+    
+    
+    @Nested
+    @DisplayName("폴더 추가")
+    class AddFolderTest {
+        
+        @Test
+        @DisplayName("응답 테스트")
+        void responseTest() throws JsonProcessingException {
+            AddFolderRequest addFolderRequest = AddFolderRequest.builder()
+                    .parentFolderId(1L)
+                    .name("뻐꾸기")
+                    .build();
+            
+            Response<FolderResponse> folderResponseResponse = folderService.addFolder(addFolderRequest, 1L);
+            String s = objectMapper.writeValueAsString(folderResponseResponse);
+            logger.info(s);
+        }
+        
+        @Test
+        @DisplayName("예외 테스트1")
+        void exceptionTest1() {
+            AddFolderRequest addFolderRequest = AddFolderRequest.builder()
+                    .parentFolderId(100L)
+                    .name("뻐꾸기")
+                    .build();
+            
+            assertThatThrownBy(() -> folderService.addFolder(addFolderRequest, 1L))
+                    .isInstanceOf(ResourceConflictException.class).hasMessage("존재 하지 않는 상위 폴더입니다.");
+        }
+        
+        @Test
+        @DisplayName("예외 테스트2")
+        void exceptionTest2() {
+            AddFolderRequest addFolderRequest = AddFolderRequest.builder()
+                    .parentFolderId(1L)
+                    .name("뻐꾸기")
+                    .build();
+            
+            assertThatThrownBy(() -> folderService.addFolder(addFolderRequest, 100L))
+                    .isInstanceOf(ResourceConflictException.class).hasMessage("회원이 존재하지 않습니다.");
+        }
+    }
+    
+    @Nested
+    @DisplayName("폴더 경로 수정")
+    class SetFolderTest {
+        
+        @Test
+        @DisplayName("응답 테스트")
+        void responseTest() throws JsonProcessingException {
+            SetFolderPathRequest setFolderPathRequest = SetFolderPathRequest.builder()
+                    .targetFolderId(2L).build();
+            
+            Response<FolderResponse> folderResponseResponse =
+                    folderService.setFolderPath(setFolderPathRequest, 4L);
+            
+            String s = objectMapper.writeValueAsString(folderResponseResponse);
+            logger.info(s);
+        }
+        
+        @Test
+        @DisplayName("예외 테스트1")
+        void exceptionTest1() {
+            SetFolderPathRequest setFolderPathRequest = SetFolderPathRequest.builder()
+                    .targetFolderId(200L).build();
+            
+            assertThatThrownBy(() -> folderService.setFolderPath(setFolderPathRequest, 4L))
+                    .isInstanceOf(ResourceConflictException.class).hasMessage("목표 부모 폴더가 존재하지 않습니다.");
+            
+        }
+        
+        @Test
+        @DisplayName("예외 테스트2")
+        void exceptionTest2() {
+            SetFolderPathRequest setFolderPathRequest = SetFolderPathRequest.builder()
+                    .targetFolderId(4L).build();
+            
+            assertThatThrownBy(() -> folderService.setFolderPath(setFolderPathRequest, 2L)).
+                    isInstanceOf(ResourceConflictException.class)
+                    .hasMessage("직계 자손을 목표 부모 폴더로 지정 할 수 없습니다.");
+        }
+    }
+    
+    @Nested
+    @DisplayName("폴더 이름 수정")
+    class SetFolderNameTest {
+        
+        @Test
+        @DisplayName("응답 테스트")
+        void responseTest() throws JsonProcessingException {
+            SetFolderNameRequest setFolderNameRequest = SetFolderNameRequest.builder()
+                    .name("스프링")
+                    .build();
+            
+            Response<FolderResponse> folderResponseResponse = folderService.setFolderName(setFolderNameRequest, 1L);
+            String s = objectMapper.writeValueAsString(folderResponseResponse);
+            logger.info(s);
+        }
+        
+        @Test
+        @DisplayName("예외 테스트")
+        void exceptionTest() {
+            SetFolderNameRequest setFolderNameRequest = SetFolderNameRequest.builder()
+                    .name("스프링")
+                    .build();
+            assertThatThrownBy(() -> folderService.setFolderName(setFolderNameRequest, 100L))
+                    .isInstanceOf(ResourceConflictException.class).hasMessage("해당 폴더가 존재하지 않아 수정을 할 수 없습니다.");
+        }
+    }
+    
+    @Nested
+    @DisplayName("폴더 삭제 테스트")
+    class DeleteFolderTest {
+        
+        @Test
+        @DisplayName("응답 테스트")
+        void responseTest() throws JsonProcessingException {
+            Response<FolderResponse> folderResponseResponse = folderService.deleteFolder(1L);
+            String s = objectMapper.writeValueAsString(folderResponseResponse);
+            logger.info(s);
+        }
+        
+        @Test
+        @DisplayName("예외 테스트")
+        void exceptionTest() {
+            assertThatThrownBy(() -> folderService.deleteFolder(100L)).
+                    isInstanceOf(ResourceConflictException.class)
+                    .hasMessage("해당 폴더가 존재하지 않아 삭제 할 수 없습니다.");
+        }
+    }
+}

--- a/src/test/java/com/wnis/linkyway/service/tag/TagServiceImplTest.java
+++ b/src/test/java/com/wnis/linkyway/service/tag/TagServiceImplTest.java
@@ -1,0 +1,237 @@
+package com.wnis.linkyway.service.tag;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.wnis.linkyway.dto.Response;
+import com.wnis.linkyway.dto.tag.TagRequest;
+import com.wnis.linkyway.entity.Member;
+import com.wnis.linkyway.entity.Tag;
+import com.wnis.linkyway.exception.common.ResourceConflictException;
+import com.wnis.linkyway.repository.MemberRepository;
+import com.wnis.linkyway.repository.TagRepository;
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.test.context.jdbc.Sql;
+
+import javax.persistence.EntityManager;
+import java.util.Arrays;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+@DataJpaTest
+@Import(TagServiceImpl.class)
+@AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
+@Sql("/sqltest/initialize-test.sql")
+class TagServiceImplTest {
+    
+    @Autowired
+    TagService tagService;
+    
+    @Autowired
+    MemberRepository memberRepository;
+    
+    @Autowired
+    TagRepository tagRepository;
+    
+    @Autowired
+    EntityManager entityManager;
+    
+    @Nested
+    @DisplayName("태그 추가 테스트")
+    class addTagTest {
+        
+        @Test
+        @DisplayName("중복에 의한 예외 상황")
+        void failTest() {
+            TagRequest tagRequest = TagRequest.builder()
+                    .tagName("spring")
+                    .build();
+            Member member = Member.builder()
+                    .email("hello@naver.com")
+                    .nickname("aasd12")
+                    .password("a!asdD@12321")
+                    .build();
+            Tag tag = Tag.builder()
+                    .member(member)
+                    .name("spring")
+                    .shareable(true)
+                    .build();
+            
+            tagRepository.save(tag);
+            memberRepository.save(member);
+            assertThatThrownBy(() -> {
+                tagService.addTag(tagRequest, 1L);
+            }).isInstanceOf(ResourceConflictException.class);
+            
+        }
+        
+        @Test
+        @DisplayName("성공 테스트")
+        void successTest() {
+            TagRequest tagRequest = TagRequest.builder()
+                    .tagName("spring")
+                    .build();
+            Member member = Member.builder()
+                    .email("hello@naver.com")
+                    .nickname("aasd12")
+                    .password("a!asdD@12321")
+                    .build();
+            Tag tag = Tag.builder()
+                    .member(member)
+                    .name("food")
+                    .shareable(true)
+                    .build();
+            
+            memberRepository.save(member);
+            tagRepository.save(tag);
+            
+            
+            tagService.addTag(tagRequest, 1L);
+            tagRepository.findAll().forEach((t) -> {
+                assertThat(t).isNotNull();
+                assertThat(t.getMember().getId()).isEqualTo(1L);
+            });
+        }
+    }
+    
+    @Nested
+    @DisplayName("태그 수정 테스트")
+    class setTagTest {
+        
+        @Test
+        @DisplayName("수정 성공한 경우")
+        void successTest() {
+            TagRequest tagRequest = TagRequest.builder()
+                    .tagName("spring")
+                    .shareable("true")
+                    .build();
+            Member member = Member.builder()
+                    .email("hello@naver.com")
+                    .nickname("aasd12")
+                    .password("a!asdD@12321")
+                    .build();
+            Tag tag = Tag.builder()
+                    .member(member)
+                    .name("food")
+                    .shareable(true)
+                    .build();
+            tagRepository.save(tag);
+            
+            tagService.setTag(tagRequest, 1L);
+            assertThat(tagRepository.findById(1L).get()).isInstanceOfSatisfying(Tag.class, (t) -> {
+                assertThat(tag.getName()).isEqualTo("spring");
+                assertThat(tag.getShareable()).isEqualTo(true);
+            });
+        }
+        
+        @Test
+        @DisplayName("데이터가 없어서 수정 실패한 경우")
+        void failTest() {
+            TagRequest tagRequest = TagRequest.builder()
+                    .tagName("spring")
+                    .shareable("true")
+                    .build();
+            Member member = Member.builder()
+                    .email("hello@naver.com")
+                    .nickname("aasd12")
+                    .password("a!asdD@12321")
+                    .build();
+            Tag tag = Tag.builder()
+                    .member(member)
+                    .name("food")
+                    .shareable(true)
+                    .build();
+            tagRepository.save(tag);
+            
+            Assertions.assertThatThrownBy(() -> {
+                tagService.setTag(tagRequest, 2L);
+            }).isInstanceOf(ResourceConflictException.class);
+        }
+    }
+    
+    @Nested
+    @DisplayName("태그 삭제 테스트")
+    class DeleteTagTest {
+        
+        @Test
+        @DisplayName("삭제 성공")
+        void successTest() {
+            TagRequest tagRequest = TagRequest.builder()
+                    .tagName("spring")
+                    .shareable("true")
+                    .build();
+            Member member = Member.builder()
+                    .email("hello@naver.com")
+                    .nickname("aasd12")
+                    .password("a!asdD@12321")
+                    .build();
+            Tag tag1 = Tag.builder()
+                    .name("food")
+                    .shareable(true)
+                    .build();
+            
+            Tag tag2 = Tag.builder()
+                    .name("food2")
+                    .shareable(true)
+                    .build();
+            
+            member.addTag(tag1);
+            member.addTag(tag2);
+            
+            memberRepository.save(member);
+            tagRepository.save(tag1);
+            tagRepository.save(tag2);
+            
+            tagService.deleteTag(1L);
+            assertThat(tagRepository.findAll().size()).isEqualTo(1);
+        }
+    }
+    
+    @Nested
+    @DisplayName("태그 조회 테스트")
+    class SearchTagsTest {
+        
+        @Test
+        @DisplayName("태그 조회 테스트")
+        void successTest() throws JsonProcessingException {
+            Member member = Member.builder()
+                    .email("hello@naver.com")
+                    .nickname("aasd12")
+                    .password("a!asdD@12321")
+                    .build();
+            Tag tag1 = Tag.builder()
+                    .name("food")
+                    .shareable(true)
+                    .build();
+            
+            Tag tag2 = Tag.builder()
+                    .name("food2")
+                    .shareable(false)
+                    .build();
+            
+            Tag tag3 = Tag.builder()
+                    .name("food3")
+                    .shareable(true)
+                    .build();
+            
+            member.addTag(tag1)
+                    .addTag(tag2)
+                    .addTag(tag3);
+            
+            memberRepository.save(member);
+            tagRepository.saveAll(Arrays.asList(tag1, tag2, tag3));
+            
+            Response tagResponseList = tagService.searchTags(1L);
+            ObjectMapper objectMapper = new ObjectMapper();
+            String s = objectMapper.writeValueAsString(tagResponseList);
+            System.out.println(s);
+        }
+    }
+}


### PR DESCRIPTION
# 특이사항

## 폴더 엔티티에 여러 기능 및 캐스케이드 remove 추가

- casecade remove를 children과 cards에 추가함
    -  해당 폴더 제거시 하위 폴더와 카드 모두 제거됨.
    - 상위 폴더는 그대로 유지됨
    - 카드의 경우 아직 테스트 못해봄
- 엔티티에 directAncestor() 불리언 메서드 추가
    - 직계 조상인지 판단함. 
        - 예외로 illegalStateException을 사용했는데 논의가 필요한 부분
    - modifyParent() 메서드는 기존 부모와의 관계를 끊고 다른 부모와 연결함
        - 양방향 링크드 리스트로 이루어진 트리이기 때문에 단순히 붙이기만 하면 안됨
        - 만약 직계후손에 붙일 경우 cycle이 형성 되기 때문에 직계 조상 메서드를 이용해 직계후손 인지 판단해야함
        - 해당 로직은 repository에서 테스트함.
        

## 테스트 방식

- 레포지토리에선 db와 구현 로직 및 메서드 테스트
- 서비스에선 응답과 예외 테스트
- 컨트롤러에서는 ResponseEntity 응답과 예외 핸들링 응답 테스트
로 기준을 나눠서 테스트함.

## 요청 DTO

- 설계에 dto부분 내용에는 없는 내용이 추가 되서 업데이트 예정
    - 유효성 검증 null, pattern 추가
    - dto 검증 테스트 진행


## 응답 DTO

- 기존 응답 DTO에 BFS를 활용해 재귀 트리 구조 DTO를 생성하도록 구현
- 서비스와 컨트롤러 응답 테스트를 통해 결과 확인 가능

## 기타사항

- 트랜잭션시 Auto_increment는 초기화가 안되기 때문에 SQL문으로 강제로 초기화를 진행함.

