### PR TITLE
Feat/#48/mapstruct

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -47,6 +47,9 @@ dependencies {
 
     implementation group: 'org.apache.httpcomponents', name: 'httpclient', version: '4.5.13'
 
+    // map struct
+    implementation 'org.mapstruct:mapstruct:1.4.2.Final'
+    annotationProcessor 'org.mapstruct:mapstruct-processor:1.4.2.Final'
 }
 
 tasks.named('test') {

--- a/src/main/java/com/wnis/linkyway/util/mapper/MemberMapper.java
+++ b/src/main/java/com/wnis/linkyway/util/mapper/MemberMapper.java
@@ -1,0 +1,25 @@
+package com.wnis.linkyway.util.mapper;
+
+import com.wnis.linkyway.dto.member.JoinRequest;
+import com.wnis.linkyway.dto.member.MemberResponse;
+import com.wnis.linkyway.entity.Member;
+import org.mapstruct.Mapper;
+import org.mapstruct.Mapping;
+import org.mapstruct.factory.Mappers;
+
+
+@Mapper(componentModel = "spring")
+public interface MemberMapper {
+    
+    MemberMapper instance = Mappers.getMapper(MemberMapper.class);
+    
+    
+    Member joinRequestToMember(JoinRequest joinRequest);
+    @Mapping(source = "id", target="memberId")
+    @Mapping(target = "email", ignore = true)
+    @Mapping(target = "nickname", ignore = true)
+    MemberResponse memberToJoinResponse(Member member);
+    
+    
+    
+}

--- a/src/test/java/com/wnis/linkyway/util/mapper/MemberMapperTest.java
+++ b/src/test/java/com/wnis/linkyway/util/mapper/MemberMapperTest.java
@@ -1,0 +1,74 @@
+package com.wnis.linkyway.util.mapper;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.wnis.linkyway.dto.member.JoinRequest;
+import com.wnis.linkyway.dto.member.MemberResponse;
+import com.wnis.linkyway.entity.Member;
+import com.wnis.linkyway.repository.MemberRepository;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.test.context.jdbc.Sql;
+
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+
+@DataJpaTest
+@AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
+@Sql("/sqltest/initialize-test.sql")
+@Import({ObjectMapper.class})
+class MemberMapperTest {
+    private final Logger logger = LoggerFactory.getLogger(MemberMapperTest.class);
+    @Autowired
+    MemberRepository memberRepository;
+    
+    @Autowired
+    ObjectMapper objectMapper;
+    
+    
+    @Test
+    @DisplayName("JoinReqest -> Member 매핑 테스트")
+    void shouldReturnMemberFromJoinRequest() throws JsonProcessingException {
+        JoinRequest joinRequest = JoinRequest.builder()
+                .email("hellowolrd@naver.com")
+                .password("aasaq!12@qA")
+                .nickname("hello").build();
+        
+        Member member = Member.builder()
+                .email("hellowolrd@naver.com")
+                .password("aasaq!12@qA")
+                .nickname("hello")
+                .build();
+        
+        Member member1 = MemberMapper.instance.joinRequestToMember(joinRequest);
+        
+        logger.info("리턴 값 : {}", objectMapper.writeValueAsString(member));
+        
+        assertThat(member1.getEmail()).isEqualTo(member.getEmail());
+        assertThat(member1.getPassword()).isEqualTo(member1.getPassword());
+        assertThat(member1.getNickname()).isEqualTo(member1.getNickname());
+    }
+    
+    @Test
+    @DisplayName("Member -> Response 매핑 테스트")
+    void shouldReturnMemberResponseFormMember() throws JsonProcessingException {
+        Member member = Member.builder()
+                .email("hellowolrd@naver.com")
+                .password("aasaq!12@qA")
+                .nickname("hello")
+                .build();
+        
+        memberRepository.save(member);
+        
+        MemberResponse memberResponse = MemberMapper.instance.memberToJoinResponse(member);
+        logger.info("리턴 값 : {}", objectMapper.writeValueAsString(memberResponse));
+        
+    }
+}


### PR DESCRIPTION
# MapStruct

- 인터페이스를 생성해서 매핑 설정을 하는 라이브러리

# 우리 프로젝트에 적용하면 좋은 이유

-  Response를 하나로 만들고 인터페이스 메서드 호출을 통해서 하나의 DTO 로 다양한 응답을 만들 수 있음.

# 장점
- 서비스 구성 시 dto <-> 엔티티간 변환 작업이 많은 데 그 때 작성하는 코드를 줄여줌..
- 이름이 일치하는 경우 자동으로 매핑해줌
- 매핑을 원치 않으면 ignore로 처리 할 수 있음.

# 단점
- string 으로 매핑하다 보니 정학히 찾아서 매핑해야함..

