### PR TITLE
닉네임 중복 처리 관련 기능 추가

### DIFF
--- a/src/main/java/com/wnis/linkyway/controller/MemberController.java
+++ b/src/main/java/com/wnis/linkyway/controller/MemberController.java
@@ -36,6 +36,12 @@ public class MemberController {
         Response<MemberResponse> response = memberService.searchEmail(email);
         return ResponseEntity.status(response.getCode()).body(response);
     }
+
+    @GetMapping("/nickname")
+    public ResponseEntity<Response<DuplicationResponse>> searchNicknameDuplicationInfo(@RequestParam String nickname) {
+        Response<DuplicationResponse> response = memberService.isValidNickname(nickname);
+        return  ResponseEntity.status(response.getCode()).body(response);
+    }
     
     @GetMapping("/mypage")
     @Authenticated

--- a/src/main/java/com/wnis/linkyway/dto/member/DuplicationResponse.java
+++ b/src/main/java/com/wnis/linkyway/dto/member/DuplicationResponse.java
@@ -1,0 +1,12 @@
+package com.wnis.linkyway.dto.member;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class DuplicationResponse {
+
+    private final boolean usable;
+
+}

--- a/src/main/java/com/wnis/linkyway/repository/MemberRepository.java
+++ b/src/main/java/com/wnis/linkyway/repository/MemberRepository.java
@@ -12,4 +12,6 @@ public interface MemberRepository extends JpaRepository<Member, Long> {
 
     boolean existsByEmail(String email);
 
+    boolean existsByNickname(String nickname);
+
 }

--- a/src/test/java/com/wnis/linkyway/controller/MemberControllerIntegrationTest.java
+++ b/src/test/java/com/wnis/linkyway/controller/MemberControllerIntegrationTest.java
@@ -206,5 +206,20 @@ class MemberControllerIntegrationTest {
                     .andReturn();
         }
     }
+
+    @Nested
+    @DisplayName("닉네임 중복 여부 조회 테스트")
+    class searchNicknameDuplicationInfoTest {
+
+        @Test
+        @DisplayName("응답 테스트")
+        void responseTest() throws Exception {
+            mockMvc.perform(
+                    get("/api/members/nickname")
+                            .param("nickname","Zeratu1"))
+                    .andExpect(status().isOk())
+                    .andDo(print());
+        }
+    }
     
 }


### PR DESCRIPTION

**Issue**

-resolves #62

**추가 사항**

- 닉네임 중복 여부 검증 메소드 추가
  - 회원가입, 닉네임 수정 등에 사용
  
- 닉네임 사용 가능 여부 조회 메소드 추가
  - 사용 가능: true , 사용 불가 : false

- `GET: /api/members/nickname` api 추가
