### PR TITLE
카드와 폴더간 연관관계 설정

### DIFF
--- a/src/main/java/com/wnis/linkyway/controller/CardController.java
+++ b/src/main/java/com/wnis/linkyway/controller/CardController.java
@@ -18,6 +18,8 @@ import com.wnis.linkyway.dto.Response;
 import com.wnis.linkyway.dto.card.AddCardResponse;
 import com.wnis.linkyway.dto.card.CardRequest;
 import com.wnis.linkyway.dto.card.CardResponse;
+import com.wnis.linkyway.security.annotation.Authenticated;
+import com.wnis.linkyway.security.annotation.CurrentMember;
 import com.wnis.linkyway.service.card.CardService;
 import com.wnis.linkyway.validation.ValidationSequence;
 
@@ -31,10 +33,11 @@ public class CardController {
     private final CardService cardService;
 
     @PostMapping
-    public ResponseEntity<Response> addCard(
+    @Authenticated
+    public ResponseEntity<Response> addCard(@CurrentMember Long memberId,
             @Validated(ValidationSequence.class) @RequestBody CardRequest cardRequest) {
 
-        AddCardResponse addCardResponse = cardService.addCard(cardRequest);
+        AddCardResponse addCardResponse = cardService.addCard(memberId, cardRequest);
 
         return ResponseEntity.created(URI.create("/card/" + addCardResponse))
                              .body(Response.builder()
@@ -45,6 +48,7 @@ public class CardController {
     }
 
     @GetMapping("/{cardId}")
+    @Authenticated
     public ResponseEntity<Response> findCardByCardId(Long cardId) {
 
         CardResponse cardResponse = cardService.findCardByCardId(cardId);
@@ -58,10 +62,12 @@ public class CardController {
     }
 
     @PutMapping("/{cardId}")
-    public ResponseEntity<Response> updateCard(@PathVariable Long cardId,
+    @Authenticated
+    public ResponseEntity<Response> updateCard(@CurrentMember Long memberId,
+            @PathVariable Long cardId,
             @Validated(ValidationSequence.class) @RequestBody CardRequest cardRequest) {
 
-        cardService.updateCard(cardId, cardRequest);
+        cardService.updateCard(memberId, cardId, cardRequest);
 
         return ResponseEntity.ok()
                              .body(Response.builder()
@@ -71,6 +77,7 @@ public class CardController {
     }
 
     @DeleteMapping("/{cardId}")
+    @Authenticated
     public ResponseEntity<Response> deleteCard(@PathVariable Long cardId) {
 
         cardService.deleteCard(cardId);

--- a/src/main/java/com/wnis/linkyway/dto/card/CardRequest.java
+++ b/src/main/java/com/wnis/linkyway/dto/card/CardRequest.java
@@ -1,6 +1,8 @@
 package com.wnis.linkyway.dto.card;
 
 import com.wnis.linkyway.entity.Card;
+import com.wnis.linkyway.entity.Folder;
+
 import lombok.*;
 
 import javax.validation.constraints.NotBlank;
@@ -31,12 +33,13 @@ public class CardRequest {
     @NotNull(message = "폴더아이디는 필수입니다.", groups = NotBlankGroup.class)
     private Long folderId;
 
-    public Card toEntity() {
+    public Card toEntity(Folder folder) {
         return Card.builder()
                    .link(link)
                    .title(title)
                    .content(content)
                    .shareable(shareable)
+                   .folder(folder)
                    .build();
     }
 }

--- a/src/main/java/com/wnis/linkyway/entity/Card.java
+++ b/src/main/java/com/wnis/linkyway/entity/Card.java
@@ -72,4 +72,8 @@ public class Card {
     public void updateShareable(boolean shareable) {
         this.shareable = shareable;
     }
+    
+    public void updateFolder(Folder folder) {
+        this.folder = folder;
+    }
 }

--- a/src/main/java/com/wnis/linkyway/repository/FolderRepository.java
+++ b/src/main/java/com/wnis/linkyway/repository/FolderRepository.java
@@ -2,6 +2,8 @@ package com.wnis.linkyway.repository;
 
 
 import com.wnis.linkyway.entity.Folder;
+import com.wnis.linkyway.entity.Member;
+
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
@@ -23,4 +25,5 @@ public interface FolderRepository extends JpaRepository<Folder, Long> {
             "values ('default', 1, null, :memberId)", nativeQuery = true)
     public void addSuperFolder(@Param("memberId") Long memberId);
     
+    public Optional<Folder> findByIdAndMember(Long id, Member member);
 }

--- a/src/main/java/com/wnis/linkyway/service/card/CardService.java
+++ b/src/main/java/com/wnis/linkyway/service/card/CardService.java
@@ -7,11 +7,11 @@ import com.wnis.linkyway.entity.Card;
 
 public interface CardService {
 
-    public AddCardResponse addCard(CardRequest cardRequest);
+    public AddCardResponse addCard(Long memberId, CardRequest cardRequest);
 
     public CardResponse findCardByCardId(Long cardId);
     
-    public Card updateCard(Long cardId, CardRequest cardRequest);
+    public Card updateCard(Long memberId, Long cardId, CardRequest cardRequest);
     
     public void deleteCard(Long cardId);
 }

--- a/src/main/java/com/wnis/linkyway/service/card/CardServiceImpl.java
+++ b/src/main/java/com/wnis/linkyway/service/card/CardServiceImpl.java
@@ -32,7 +32,7 @@ public class CardServiceImpl implements CardService {
 
     @Override
     @Transactional
-    public AddCardResponse addCard(CardRequest cardRequest) {
+    public AddCardResponse addCard(Long memberId, CardRequest cardRequest) {
         Card savedCard = cardRepository.save(cardRequest.toEntity());
         addCardTagByCard(savedCard, cardRequest.getTagIdSet());
 
@@ -64,7 +64,8 @@ public class CardServiceImpl implements CardService {
 
     @Override
     @Transactional
-    public Card updateCard(Long cardId, CardRequest cardRequest) {
+    public Card updateCard(Long memberId, Long cardId,
+            CardRequest cardRequest) {
         Card card = cardRepository.findById(cardId)
                                   .orElseThrow(
                                           () -> new NotModifyEmptyEntityException(

--- a/src/main/java/com/wnis/linkyway/service/card/CardServiceImpl.java
+++ b/src/main/java/com/wnis/linkyway/service/card/CardServiceImpl.java
@@ -85,6 +85,17 @@ public class CardServiceImpl implements CardService {
                                   .orElseThrow(
                                           () -> new NotModifyEmptyEntityException(
                                                   "해당 카드가 존재하지 않아 수정이 불가능합니다"));
+        Folder oldFolder = card.getFolder();
+        if (cardRequest.getFolderId() != oldFolder.getId()) {
+            Member member = oldFolder.getMember();
+            Folder folder = folderRepository.findByIdAndMember(
+                    cardRequest.getFolderId(), member)
+                                            .orElseThrow(
+                                                    () -> new NotFoundEntityException(
+                                                            "해당 폴더가 존재하지 않습니다. 폴더를 먼저 생성해주세요."));
+            card.updateFolder(folder);
+        }
+
         card.updateLink(cardRequest.getLink());
         card.updateTitle(cardRequest.getTitle());
         card.updateContent(cardRequest.getContent());


### PR DESCRIPTION
### 생성
- **카드 생성 시** 
    - 입력된 폴더 아이디가 사용자의 소유가 맞는지 확인
- **카드 수정 시** 
    - 입력된 폴더 아이디가 사용자의 소유가 맞는지 확인
    - 기존에 입력되어있는 폴더id와 새로운 폴더id가 다를 경우 수정

### 삭제
- 예외 처리:  카드 존재 확인
- 연관 삭제:  카드가 삭제되었을 경우 폴더는 삭제되지 않아야함.