### PR TITLE
Feat/#79/폴더 방식 수정

### DIFF
--- a/src/main/java/com/wnis/linkyway/controller/FolderController.java
+++ b/src/main/java/com/wnis/linkyway/controller/FolderController.java
@@ -15,6 +15,8 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.*;
 
+import java.util.List;
+
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/api/folders")
@@ -25,7 +27,7 @@ public class FolderController {
     @GetMapping("/super")
     @Authenticated
     public ResponseEntity<Response> searchFolderSuper(@CurrentMember Long memberId) {
-        Response<FolderResponse> response = folderService.findFolderSuper(memberId);
+        Response<List<FolderResponse>> response = folderService.findAllFolderSuper(memberId);
         return ResponseEntity.status(response.getCode()).body(response);
     }
     

--- a/src/main/java/com/wnis/linkyway/dto/folder/AddFolderRequest.java
+++ b/src/main/java/com/wnis/linkyway/dto/folder/AddFolderRequest.java
@@ -5,7 +5,6 @@ import com.wnis.linkyway.validation.ValidationGroup;
 import lombok.*;
 
 import javax.validation.constraints.NotBlank;
-import javax.validation.constraints.NotNull;
 import javax.validation.constraints.Pattern;
 import javax.validation.constraints.Positive;
 
@@ -15,7 +14,6 @@ import javax.validation.constraints.Positive;
 @Builder
 public class AddFolderRequest {
     
-    @NotNull(message = "부모 폴더 id를 입력해주세요", groups = ValidationGroup.NotBlankGroup.class)
     @Positive(message = "parentFolderId는 0 이상의 id를 입력하셔야 합니다.")
     private Long parentFolderId;
     

--- a/src/main/java/com/wnis/linkyway/exception/common/LimitDepthException.java
+++ b/src/main/java/com/wnis/linkyway/exception/common/LimitDepthException.java
@@ -1,0 +1,7 @@
+package com.wnis.linkyway.exception.common;
+
+public class LimitDepthException extends ResourceConflictException{
+    public LimitDepthException(String message) {
+        super(message);
+    }
+}

--- a/src/main/java/com/wnis/linkyway/repository/FolderRepository.java
+++ b/src/main/java/com/wnis/linkyway/repository/FolderRepository.java
@@ -21,7 +21,7 @@ public interface FolderRepository extends JpaRepository<Folder, Long> {
     
     @Modifying
     @Query(value = "insert into folder (name, depth, parent_folder_id, member_member_id) " +
-            "values ('default', 1, null, :memberId)", nativeQuery = true)
+            "values ('default', 0, null, :memberId)", nativeQuery = true)
     public void addSuperFolder(@Param("memberId") Long memberId);
     
 }

--- a/src/main/java/com/wnis/linkyway/repository/FolderRepository.java
+++ b/src/main/java/com/wnis/linkyway/repository/FolderRepository.java
@@ -7,6 +7,7 @@ import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
+import java.util.List;
 import java.util.Optional;
 
 public interface FolderRepository extends JpaRepository<Folder, Long> {
@@ -14,9 +15,9 @@ public interface FolderRepository extends JpaRepository<Folder, Long> {
             "where f.id = :folderId")
     public Optional<Folder> findFolderById(@Param("folderId") Long folderId);
     
-    @Query("select f from Folder f left outer join fetch f.parent " +
-            "join f.member as m where m.id = :memberId and f.depth = 1")
-    public Optional<Folder> findFolderByMemberId(@Param("memberId") Long memberId);
+    @Query("select f from Folder f left join fetch f.parent join f.member " +
+            "where f.member.id = :memberId and f.depth <= 1 ")
+    public List<Folder> findAllSuperFolder(@Param("memberId") Long memberId);
     
     @Modifying
     @Query(value = "insert into folder (name, depth, parent_folder_id, member_member_id) " +

--- a/src/main/java/com/wnis/linkyway/service/folder/FolderService.java
+++ b/src/main/java/com/wnis/linkyway/service/folder/FolderService.java
@@ -7,9 +7,11 @@ import com.wnis.linkyway.dto.folder.FolderResponse;
 import com.wnis.linkyway.dto.folder.SetFolderNameRequest;
 import com.wnis.linkyway.dto.folder.SetFolderPathRequest;
 
+import java.util.List;
+
 public interface FolderService {
     
-    Response<FolderResponse> findFolderSuper(Long memberId);
+    Response<List<FolderResponse>>  findAllFolderSuper(Long memberId);
     
     Response<FolderResponse> findFolder(Long folderId);
     

--- a/src/main/java/com/wnis/linkyway/service/folder/FolderServiceImpl.java
+++ b/src/main/java/com/wnis/linkyway/service/folder/FolderServiceImpl.java
@@ -11,9 +11,13 @@ import com.wnis.linkyway.exception.common.*;
 import com.wnis.linkyway.repository.FolderRepository;
 import com.wnis.linkyway.repository.MemberRepository;
 import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+
+import java.util.ArrayList;
+import java.util.List;
 
 
 @Service("folderService")
@@ -24,12 +28,22 @@ public class FolderServiceImpl implements FolderService {
     private final FolderRepository folderRepository;
     private final MemberRepository memberRepository;
     
+    @Value("${folder.limit.depth}")
+    private Long limitDepth;
+    
     @Override
-    public Response<FolderResponse> findFolderSuper(Long memberId) {
-        Folder folder = folderRepository.findFolderByMemberId(memberId).orElseThrow(()->
-                new NotFoundEntityException("해당 회원의 최상위 폴더를 조회 할 수 없습니다"));
-        FolderResponse folderResponse = new FolderResponse(folder);
-        return Response.of(HttpStatus.OK, folderResponse, "폴더 조회 성공");
+    public Response<List<FolderResponse>> findAllFolderSuper(Long memberId) {
+        if (!memberRepository.existsById(memberId)) {
+            throw new NotFoundEntityException("존재하지 않는 회원입니다");
+        }
+        List<Folder> folderList = folderRepository.findAllSuperFolder(memberId);
+        List<FolderResponse> response = new ArrayList<>();
+        for (Folder folder : folderList) {
+            FolderResponse folderResponse = new FolderResponse(folder);
+            response.add(folderResponse);
+            
+        }
+        return Response.of(HttpStatus.OK, response, "폴더 조회 성공");
     }
     
     @Override
@@ -46,19 +60,43 @@ public class FolderServiceImpl implements FolderService {
         Member member = memberRepository.findById(memberId).orElseThrow(() ->
             new NotFoundEntityException("회원이 존재하지 않습니다")
         );
-        Folder parent = folderRepository.findFolderById(addFolderRequest.getParentFolderId()).orElseThrow(() ->
-            new ResourceConflictException("존재 하지 않는 상위 폴더에 새로운 폴더를 추가 할 수 없습니다")
-        );
+        
+        Long currentDepth = 1L;
+        Long parentId = null;
+        Folder parent = null;
+        
+        if (addFolderRequest.getParentFolderId() != null) {
+            parent = folderRepository.findFolderById(addFolderRequest.getParentFolderId()).orElseThrow(()->
+                    new ResourceNotFoundException("해당 상위 폴더가 존재하지 않습니다"));
+        }
+        
+        
+        if (parent != null) {
+            currentDepth = parent.getDepth() + 1;
+            parentId = parent.getId();
+    
+            if (parent.getDepth() == 0L) {
+                throw new ResourceConflictException("default 폴더에는 임의의 하위 폴더를 추가 할 수 없습니다");
+            }
+            if (currentDepth > limitDepth) {
+                throw new LimitDepthException(
+                        String.format("현재 폴더 깊이가 %d 를 초과하여 더 이상 깊이의 폴더를 추가 할 수 없습니다", limitDepth));
+            }
+        }
+        
+        
         Folder folder = Folder.builder()
                 .member(member)
                 .name(addFolderRequest.getName())
-                .depth(parent.getDepth() + 1)
+                .depth(currentDepth)
                 .parent(parent)
                 .build();
         
         folderRepository.save(folder);
         FolderResponse response = FolderResponse.builder()
-                .folderId(folder.getParent().getId())
+                .parentId(parentId)
+                .folderId(folder.getId())
+                .level(folder.getDepth())
                 .build();
         return Response.of(HttpStatus.OK, response, "폴더 생성 성공");
     }
@@ -77,6 +115,12 @@ public class FolderServiceImpl implements FolderService {
         if (destinationFolder.isDirectAncestor(folder)) {
             throw new ResourceConflictException("직계 자손을 목표 부모 폴더로 지정 할 수 없습니다");
         }
+        
+        if (destinationFolder.getDepth() >= limitDepth) {
+            throw new LimitDepthException(
+                    String.format("깊이가 %d 이상인 폴더의 하위 경로로 디렉토리를 변경 할 수 없습니다", limitDepth));
+        }
+        
         folder.modifyParent(destinationFolder);
         return Response.of(HttpStatus.OK, null, "폴더 경로가 성공적으로 수정되었습니다");
         

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -17,6 +17,7 @@ spring:
   config:
     import:
       - classpath:jwt.yml
+      - classpath:folder.yml
 
 
 logging:

--- a/src/main/resources/folder.yml
+++ b/src/main/resources/folder.yml
@@ -1,0 +1,3 @@
+folder:
+  limit:
+    depth: 2

--- a/src/test/java/com/wnis/linkyway/controller/folder/FolderControllerIntegrationTest.java
+++ b/src/test/java/com/wnis/linkyway/controller/folder/FolderControllerIntegrationTest.java
@@ -69,21 +69,21 @@ public class FolderControllerIntegrationTest {
         
         Folder folder1 = Folder.builder()
                 .member(member1)
-                .depth(1L)
+                .depth(0L)
                 .name("f1")
                 .build();
         
         Folder folder2 = Folder.builder()
                 .member(member1)
                 .name("f2")
-                .depth(2L)
-                .parent(folder1)
+                .depth(1L)
+                .parent(null)
                 .build();
         
         Folder folder3 = Folder.builder()
                 .member(member1)
                 .name("f3")
-                .depth(3L)
+                .depth(2L)
                 .parent(folder2)
                 .build();
         
@@ -150,7 +150,7 @@ public class FolderControllerIntegrationTest {
         @WithMockMember(id = 1L, email = "marrin1101@naver.com")
         void responseTest() throws Exception {
             AddFolderRequest addFolderRequest = AddFolderRequest.builder()
-                    .parentFolderId(1L)
+                    .parentFolderId(2L)
                     .name("f10")
                     .build();
             
@@ -162,6 +162,24 @@ public class FolderControllerIntegrationTest {
             
             logger.info(mvcResult.getResponse().getContentAsString());
             
+        }
+    
+        @Test
+        @DisplayName("부모 폴더에 null 을 기입한 경우")
+        @WithMockMember(id = 1L, email = "marrin1101@naver.com")
+        void RequestParentIdNull() throws Exception {
+            AddFolderRequest addFolderRequest = AddFolderRequest.builder()
+                    .parentFolderId(null)
+                    .name("f10")
+                    .build();
+        
+            MvcResult mvcResult = mockMvc.perform(post("/api/folders")
+                            .contentType("application/json")
+                            .content(objectMapper.writeValueAsBytes(addFolderRequest)))
+                    .andExpect(status().is(200))
+                    .andReturn();
+            
+        
         }
         
         @Test
@@ -192,7 +210,7 @@ public class FolderControllerIntegrationTest {
             MvcResult mvcResult = mockMvc.perform(post("/api/folders")
                             .contentType("application/json")
                             .content(objectMapper.writeValueAsBytes(addFolderRequest)))
-                    .andExpect(status().is(409))
+                    .andExpect(status().is(404))
                     .andReturn();
             
             logger.info(mvcResult.getResponse().getContentAsString());
@@ -241,11 +259,27 @@ public class FolderControllerIntegrationTest {
     @Nested
     @DisplayName("폴더 경로 수정")
     class SetFolderPathTest {
-        
+    
+    
         @Test
         @DisplayName("응답 테스트")
         @WithMockMember(id = 1L, email = "marrin1101@naver.com")
         void responseTest() throws Exception {
+            SetFolderPathRequest setFolderPathRequest = SetFolderPathRequest.builder()
+                    .targetFolderId(2L)
+                    .build();
+        
+            MvcResult mvcResult = mockMvc.perform(put("/api/folders/3/path")
+                            .contentType("application/json")
+                            .content(objectMapper.writeValueAsString(setFolderPathRequest)))
+                    .andExpect(status().is(200))
+                    .andReturn();
+        }
+        
+        @Test
+        @DisplayName("수정하려는 폴더의 깊이가 깊은 경우 테스트")
+        @WithMockMember(id = 1L, email = "marrin1101@naver.com")
+        void LimitFolderDepthTest() throws Exception {
             SetFolderPathRequest setFolderPathRequest = SetFolderPathRequest.builder()
                     .targetFolderId(5L)
                     .build();
@@ -253,10 +287,8 @@ public class FolderControllerIntegrationTest {
             MvcResult mvcResult = mockMvc.perform(put("/api/folders/3/path")
                             .contentType("application/json")
                             .content(objectMapper.writeValueAsString(setFolderPathRequest)))
-                    .andExpect(status().is(200))
+                    .andExpect(status().is(409))
                     .andReturn();
-            
-            logger.info(mvcResult.getResponse().getContentAsString());
         }
         
         @Test

--- a/src/test/java/com/wnis/linkyway/repository/FolderRepositoryTest.java
+++ b/src/test/java/com/wnis/linkyway/repository/FolderRepositoryTest.java
@@ -81,15 +81,6 @@ class FolderRepositoryTest {
     }
     
     @Test
-    @DisplayName("findFolderByMemberId 테스트")
-    void findFolderByMemberIdTest() {
-        Folder folder = folderRepository.findFolderByMemberId(1L).orElse(null);
-        logger.info(String.valueOf(folder));
-        assertThat(folder.getId()).isEqualTo(1L);
-        assertThat(folder.getName()).isEqualTo("f1");
-    }
-    
-    @Test
     @DisplayName("findFolderByFolderId 테스트")
     void findFolderByIdTest() {
         Folder folder = folderRepository.findFolderById(2L).get();


### PR DESCRIPTION
# 특이사항 및 변경점

- default 폴더 생성시 depth 0, name: "default"로 생성
- 이제 root 폴더에서 뻗어가는 방식이 아닌 추가 요청시 부모 id를 따로 기입하지 않으면 상위폴더(부모폴더), depth 1로 생성됩니다.
- 서비스의 확장성 그리고 유연성을 고려해서 depth 깊이에 대한 예외 처리 설정값(limitDepth)를 yml로 설정 할 수 있도록 했습니다.
- 생성시 이제는 현재 폴더 ID와 level(depth)를  return해줍니다.
- 경로 변경시 자식폴더(depth 2 이상) 인 폴더의 자식으로 경로를 이동 할 수 없도록 수정했습니다