### PR TITLE
Refactor/#93/태그 테이블 문서 싱크 작업

### DIFF
--- a/src/main/java/com/wnis/linkyway/dto/tag/TagRequest.java
+++ b/src/main/java/com/wnis/linkyway/dto/tag/TagRequest.java
@@ -17,7 +17,7 @@ public class TagRequest {
 
     @NotBlank(message = "소셜 공유 여부를 입력해주세요", groups = NotBlankGroup.class)
     @Pattern(regexp = "(true|false)", groups = PatternCheckGroup.class)
-    String shareable;
+    String isPublic;
 
     @NotBlank(message = "tagName을 입력해주세요", groups = NotBlankGroup.class)
     @Size(max = 10, message = "10자 이하로 작성해주세요")

--- a/src/main/java/com/wnis/linkyway/dto/tag/TagResponse.java
+++ b/src/main/java/com/wnis/linkyway/dto/tag/TagResponse.java
@@ -13,21 +13,19 @@ public class TagResponse {
 
     private Long tagId;
     private String tagName;
-    private Boolean shareable;
-    private Integer views;
+    private Boolean isPublic;
+    
 
     @Builder
-    private TagResponse(Long tagId, String tagName, Boolean shareable, Integer views) {
+    private TagResponse(Long tagId, String tagName, Boolean isPublic, Integer views) {
         this.tagId = tagId;
         this.tagName = tagName;
-        this.shareable = shareable;
-        this.views = views;
+        this.isPublic = isPublic;
     }
 
     public TagResponse(Tag tag) {
         this.tagId = tag.getId();
         this.tagName = tag.getName();
-        this.shareable = tag.getShareable();
-        this.views = tag.getViews();
+        this.isPublic = tag.getIsPublic();
     }
 }

--- a/src/main/java/com/wnis/linkyway/entity/Tag.java
+++ b/src/main/java/com/wnis/linkyway/entity/Tag.java
@@ -5,32 +5,33 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 import javax.persistence.*;
+import javax.validation.constraints.NotNull;
 import java.util.ArrayList;
 import java.util.List;
 
 @NoArgsConstructor
 @Getter
 @Entity
-@Table(name = "tag")
+@Table(name = "tag",
+indexes = {
+        @Index(name = "tag_ix_name", columnList = "name"),
+})
 public class Tag {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     @Column(name = "tag_id", nullable = false)
     private Long id;
 
-    @Column(name = "name")
+    @Column(name = "name", length = 10, nullable = false)
     private String name;
 
-    @Column(name = "shareable")
-    private Boolean shareable;
-
-    @Column(name = "views")
-    private Integer views;
-
+    @Column(name = "is_public", nullable = false)
+    private Boolean isPublic;
+    
     //// ********************연관 관게 ***************************/////
 
-    @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "member_member_id")
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
+    @JoinColumn(name = "member_member_id", nullable = false)
     private Member member;
 
     // ***** 1 : N *****
@@ -47,15 +48,11 @@ public class Tag {
         return this;
     }
 
-    public Tag updateShareable(Boolean shareable) {
-        this.shareable = shareable;
+    public Tag updateIsPublic(Boolean isPublic) {
+        this.isPublic = isPublic;
         return this;
     }
-
-    public Tag updateViews(Integer views) {
-        this.views = views;
-        return this;
-    }
+    
 
     public Tag updateMember(Member member) {
         this.member = member;
@@ -65,10 +62,9 @@ public class Tag {
     // **************** 생성자 *******************************///
 
     @Builder
-    private Tag(String name, Boolean shareable, Integer views, Member member) {
+    private Tag(String name, Boolean isPublic, Member member) {
         this.name = name;
-        this.shareable = shareable;
-        this.views = views;
+        this.isPublic = isPublic;
         this.member = member;
         if (member != null) {
             member.getTags()

--- a/src/main/java/com/wnis/linkyway/repository/TagRepository.java
+++ b/src/main/java/com/wnis/linkyway/repository/TagRepository.java
@@ -3,7 +3,6 @@ package com.wnis.linkyway.repository;
 import com.wnis.linkyway.dto.tag.TagResponse;
 import com.wnis.linkyway.entity.Tag;
 import org.springframework.data.jpa.repository.JpaRepository;
-import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
@@ -17,17 +16,10 @@ public interface TagRepository extends JpaRepository<Tag, Long> {
     public List<TagResponse> findAllTagList(@Param("memberId") Long memberId);
 
     @Query("select case when count(t) > 0 then true else false end from Tag t join t.member m "
-            + "where t.name = :name and m.id = :memberId")
-    public boolean existsByTagNameAndMemberId(@Param(value = "name") String name,
+            + "where m.id = :memberId and t.name = :name")
+    public boolean existsByMemberIdAndTagName(@Param(value = "name") String name,
             @Param(value = "memberId") Long memberId);
-
-    // 코드 변경에 따라 사용되지 않는 코드가 되어서 추후에 삭제 예정
-    @Modifying
-    @Query(value = "insert into tag (name, shareable, views, member_member_id)"
-            + "values (:name, :shareable, 0, :member_id)", nativeQuery = true)
-    public void addTag(@Param("name") String name,
-            @Param("shareable") boolean shareable,
-            @Param("member_id") Long memberId);
+    
 
     @Query("select t from Tag t join t.member m " + "where t.id = :tagId and m.id = :memberId")
     public Optional<Tag> findByIdAndMemberId(@Param(value = "memberId") Long memberId,

--- a/src/main/java/com/wnis/linkyway/service/tag/TagServiceImpl.java
+++ b/src/main/java/com/wnis/linkyway/service/tag/TagServiceImpl.java
@@ -35,14 +35,13 @@ public class TagServiceImpl implements TagService {
             throw new NotFoundEntityException("회원을 찾을 수 없습니다");
         }
 
-        if (tagRepository.existsByTagNameAndMemberId(tagRequest.getTagName(), memberId)) {
+        if (tagRepository.existsByMemberIdAndTagName(tagRequest.getTagName(), memberId)) {
             throw new NotAddDuplicateEntityException("중복된 태그 이름을 추가 할 수 없습니다");
         }
 
         Tag tag = Tag.builder()
                      .name(tagRequest.getTagName())
-                     .shareable(Boolean.parseBoolean(tagRequest.getShareable()))
-                     .views(0)
+                     .isPublic(Boolean.parseBoolean(tagRequest.getIsPublic()))
                      .member(memberRepository.getById(memberId))
                      .build();
 
@@ -57,17 +56,17 @@ public class TagServiceImpl implements TagService {
         Tag tag = tagRepository.findById(tagId)
                                .orElseThrow(() -> new NotModifyEmptyEntityException("태그가 존재하지 않아 수정 할 수 없습니다."));
 
-        if (tagRepository.existsByTagNameAndMemberId(tagRequest.getTagName(), tagId)) {
+        if (tagRepository.existsByMemberIdAndTagName(tagRequest.getTagName(), tagId)) {
             throw new NotModifyDuplicateException("이미 존재하는 태그의 이름으로 수정 할 수 없습니다");
         }
 
         tag.updateName(tagRequest.getTagName())
-           .updateShareable(Boolean.parseBoolean(tagRequest.getShareable()));
+           .updateIsPublic(Boolean.parseBoolean(tagRequest.getIsPublic()));
 
         return TagResponse.builder()
                           .tagId(tag.getId())
                           .tagName(tag.getName())
-                          .shareable(tag.getShareable())
+                          .isPublic(tag.getIsPublic())
                           .build();
     }
 

--- a/src/main/resources/sqltest/tag-test.sql
+++ b/src/main/resources/sqltest/tag-test.sql
@@ -17,19 +17,20 @@ VALUES ('pds0123@gmail.com', 'hello3', '$2a$10$BGENx/1mUjloPKZ311EGFe16UcWRM5NHy
 
 
 
-INSERT INTO tag (name, shareable, views, member_member_id)
-VALUES ('spring', 0, 0, 1);
+INSERT INTO tag (name, is_public, member_member_id)
+VALUES ('spring', 0, 1);
 
-INSERT INTO tag (name, shareable, views, member_member_id)
-VALUES ('food', 0, 0, 1);
+INSERT INTO tag (name, is_public, member_member_id)
+VALUES ('food', 0, 1);
 
-INSERT INTO tag (name, shareable, views, member_member_id)
-VALUES ('spring', 0, 0, 2);
+INSERT INTO tag (name, is_public, member_member_id)
+VALUES ('spring', 0, 2);
 
-INSERT INTO tag (name, shareable, views, member_member_id)
-VALUES ('spring', 0, 0, 3);
+INSERT INTO tag (name, is_public, member_member_id)
+VALUES ('spring', 0, 3);
 
-INSERT INTO tag (name, shareable, views, member_member_id)
-VALUES ('firewall', 1, 0, 1);
-INSERT INTO tag (name, shareable, views, member_member_id)
-VALUES ('shopping', 1, 0, 1);
+INSERT INTO tag (name, is_public, member_member_id)
+VALUES ('firewall', 1, 1);
+INSERT INTO tag (name, is_public, member_member_id)
+VALUES ('shopping', 1, 1);
+

--- a/src/test/java/com/wnis/linkyway/controller/card/PersonalSearchIntegrationTest.java
+++ b/src/test/java/com/wnis/linkyway/controller/card/PersonalSearchIntegrationTest.java
@@ -81,8 +81,9 @@ public class PersonalSearchIntegrationTest {
                             .shareable(false)
                             .build();
             Tag tag = Tag.builder()
-                         .shareable(false)
+                         .isPublic(false)
                          .name("spring")
+                         .member(member)
                          .build();
             CardTag cardTag = CardTag.builder()
                                      .card(card)

--- a/src/test/java/com/wnis/linkyway/controller/card/PersonalSearchResponseTest.java
+++ b/src/test/java/com/wnis/linkyway/controller/card/PersonalSearchResponseTest.java
@@ -21,6 +21,7 @@ import org.springframework.web.filter.CharacterEncodingFilter;
 
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.List;
 
 import static org.mockito.ArgumentMatchers.any;
@@ -60,7 +61,7 @@ public class PersonalSearchResponseTest {
         @Test
         void shouldReturnCode200Test() throws Exception {
             Tag tag = Tag.builder()
-                         .shareable(false)
+                         .isPublic(false)
                          .name("site")
                          .build();
 
@@ -69,10 +70,10 @@ public class PersonalSearchResponseTest {
                                                     .title("hello")
                                                     .link("www.google.com")
                                                     .content("hello")
-                                                    .tags(Arrays.asList(tag))
+                                                    .tags(Collections.singletonList(tag))
                                                     .build();
 
-            List<CardResponse> list = new ArrayList<>(Arrays.asList(cardResponse));
+            List<CardResponse> list = new ArrayList<>(Collections.singletonList(cardResponse));
 
             doReturn(list).when(cardService)
                           .personalSearchCardByKeyword(any(), any());

--- a/src/test/java/com/wnis/linkyway/controller/tag/TagControllerIntegrationTest.java
+++ b/src/test/java/com/wnis/linkyway/controller/tag/TagControllerIntegrationTest.java
@@ -67,8 +67,7 @@ public class TagControllerIntegrationTest {
                    .andExpect(jsonPath("$.data").isArray())
                    .andExpect(jsonPath("$..tagId").exists())
                    .andExpect(jsonPath("$..tagName").exists())
-                   .andExpect(jsonPath("$..shareable").exists())
-                   .andExpect(jsonPath("$..views").exists());
+                   .andExpect(jsonPath("$..isPublic").exists());
         }
     }
 
@@ -82,7 +81,7 @@ public class TagControllerIntegrationTest {
         void mustReturnResponseFormatExistTest() throws Exception {
             TagRequest tagRequest = TagRequest.builder()
                                               .tagName("dance")
-                                              .shareable("false")
+                                              .isPublic("false")
                                               .build();
 
             mockMvc.perform(post("/api/tags").contentType(MediaType.APPLICATION_JSON)
@@ -101,7 +100,7 @@ public class TagControllerIntegrationTest {
         void ResponseExceptionTest() throws Exception {
             TagRequest tagRequest = TagRequest.builder()
                                               .tagName("spring")
-                                              .shareable("true")
+                                              .isPublic("true")
                                               .build();
 
             MvcResult mvcResult = mockMvc.perform(post("/api/tags").contentType(MediaType.APPLICATION_JSON)
@@ -124,7 +123,7 @@ public class TagControllerIntegrationTest {
         void mustReturnResponseFormatExistTest() throws Exception {
             TagRequest tagRequest = TagRequest.builder()
                                               .tagName("dance")
-                                              .shareable("false")
+                                              .isPublic("false")
                                               .build();
 
             mockMvc.perform(put("/api/tags/1").contentType(MediaType.APPLICATION_JSON)
@@ -133,7 +132,7 @@ public class TagControllerIntegrationTest {
                    .andExpect(jsonPath("$.data").isMap())
                    .andExpect(jsonPath("$..tagId").exists())
                    .andExpect(jsonPath("$..tagName").exists())
-                   .andExpect(jsonPath("$..shareable").exists())
+                   .andExpect(jsonPath("$..isPublic").exists())
                    .andExpect(jsonPath("$..views").doesNotExist());
         }
 
@@ -143,7 +142,7 @@ public class TagControllerIntegrationTest {
         void responseExceptionTest() throws Exception {
             TagRequest tagRequest = TagRequest.builder()
                                               .tagName("Summer")
-                                              .shareable("false")
+                                              .isPublic("false")
                                               .build();
 
             MvcResult mvcResult = mockMvc.perform(put("/api/tags/4000").contentType(MediaType.APPLICATION_JSON)

--- a/src/test/java/com/wnis/linkyway/controller/tag/TagControllerTest.java
+++ b/src/test/java/com/wnis/linkyway/controller/tag/TagControllerTest.java
@@ -57,7 +57,7 @@ class TagControllerTest {
     void shouldReturn400_WhenBlankProperty(String tagName, String shareable) throws Exception {
         TagRequest tagRequest = TagRequest.builder()
                                           .tagName(tagName)
-                                          .shareable(shareable)
+                                          .isPublic(shareable)
                                           .build();
 
         mockMvc.perform(post("/api/tags/").contentType(MediaType.APPLICATION_JSON)
@@ -71,7 +71,7 @@ class TagControllerTest {
     void shouldReturn400_WhenInvalidPattern(String tagName, String shareable) throws Exception {
         TagRequest tagRequest = TagRequest.builder()
                                           .tagName(tagName)
-                                          .shareable(shareable)
+                                          .isPublic(shareable)
                                           .build();
 
         mockMvc.perform(post("/api/tags/").contentType(MediaType.APPLICATION_JSON)

--- a/src/test/java/com/wnis/linkyway/dto/tag/TagRequestTest.java
+++ b/src/test/java/com/wnis/linkyway/dto/tag/TagRequestTest.java
@@ -42,7 +42,7 @@ class TagRequestTest {
         void notBlankTest(String tagName, String shareable, int result) {
             TagRequest tagRequest = TagRequest.builder()
                                               .tagName(tagName)
-                                              .shareable(shareable)
+                                              .isPublic(shareable)
                                               .build();
 
             Set<ConstraintViolation<TagRequest>> constraintViolations = validator.validate(tagRequest,
@@ -57,7 +57,7 @@ class TagRequestTest {
         void patternTest(String tagName, String shareable, int result) {
             TagRequest tagRequest = TagRequest.builder()
                                               .tagName(tagName)
-                                              .shareable(shareable)
+                                              .isPublic(shareable)
                                               .build();
 
             Set<ConstraintViolation<TagRequest>> constraintViolations = validator.validate(tagRequest,

--- a/src/test/java/com/wnis/linkyway/dto/tag/TagResponseTest.java
+++ b/src/test/java/com/wnis/linkyway/dto/tag/TagResponseTest.java
@@ -20,14 +20,13 @@ class TagResponseTest {
         TagResponse tagResponse = TagResponse.builder()
                                              .tagName("hello")
                                              .tagId(1L)
-                                             .shareable(true)
+                                             .isPublic(true)
                                              .views(10)
                                              .build();
 
         assertThat(jacksonTester.write(tagResponse)).hasJsonPathValue("@.tagName");
         assertThat(jacksonTester.write(tagResponse)).hasJsonPathValue("@.tagId");
-        assertThat(jacksonTester.write(tagResponse)).hasJsonPathValue("@.shareable");
-        assertThat(jacksonTester.write(tagResponse)).hasJsonPathValue("@.views");
+        assertThat(jacksonTester.write(tagResponse)).hasJsonPathValue("@.isPublic");
     }
 
 }

--- a/src/test/java/com/wnis/linkyway/repository/CardRepositoryTest.java
+++ b/src/test/java/com/wnis/linkyway/repository/CardRepositoryTest.java
@@ -132,26 +132,28 @@ public class CardRepositoryTest {
 
     @Test
     void countTheNumberOfSqlCalls_UsingFindAllCardByKeyword() {
-        Tag tag1 = Tag.builder()
-                      .name("hello")
-                      .shareable(true)
-                      .views(0)
-                      .build();
-        Tag tag2 = Tag.builder()
-                      .name("hello1")
-                      .shareable(false)
-                      .views(0)
-                      .build();
-        Tag tag3 = Tag.builder()
-                      .name("hello2")
-                      .shareable(false)
-                      .views(0)
-                      .build();
         Member member = Member.builder()
                               .nickname("h")
                               .password("1")
                               .email("as@naver.com")
                               .build();
+        
+        Tag tag1 = Tag.builder()
+                      .name("hello")
+                      .isPublic(true)
+                      .member(member)
+                      .build();
+        Tag tag2 = Tag.builder()
+                      .name("hello1")
+                      .isPublic(false)
+                      .member(member)
+                      .build();
+        Tag tag3 = Tag.builder()
+                      .name("hello2")
+                      .isPublic(false)
+                      .member(member)
+                      .build();
+
         Folder folder = Folder.builder()
                               .name("1")
                               .member(member)

--- a/src/test/java/com/wnis/linkyway/repository/TagRepositoryTest.java
+++ b/src/test/java/com/wnis/linkyway/repository/TagRepositoryTest.java
@@ -34,7 +34,7 @@ class TagRepositoryTest {
                    delimiter = ',',
                    numLinesToSkip = 1)
     void existsByTagNameAndMemberIdTest(String name, Long memberId) {
-        boolean bool = tagRepository.existsByTagNameAndMemberId(name, memberId);
+        boolean bool = tagRepository.existsByMemberIdAndTagName(name, memberId);
         logger.info("result: {}", bool);
     }
 }

--- a/src/test/java/com/wnis/linkyway/service/tag/TagServiceBusinessExceptionTest.java
+++ b/src/test/java/com/wnis/linkyway/service/tag/TagServiceBusinessExceptionTest.java
@@ -41,7 +41,7 @@ public class TagServiceBusinessExceptionTest {
             doReturn(true).when(memberRepository)
                           .existsById(any()); // 회원 검증 통과
             doReturn(true).when(tagRepository)
-                          .existsByTagNameAndMemberId(any(), any()); // 중복 입력 예외
+                          .existsByMemberIdAndTagName(any(), any()); // 중복 입력 예외
 
             Assertions.assertThatThrownBy(() -> tagService.addTag(TagRequest.builder()
                                                                             .build(),
@@ -90,7 +90,7 @@ public class TagServiceBusinessExceptionTest {
                                               .findById(any());
             // 요청 tagName이랑 id로 탐색한 결과 이미 값이 존재한다면 중복 예외.
             doReturn(true).when(tagRepository)
-                          .existsByTagNameAndMemberId(any(), any());
+                          .existsByMemberIdAndTagName(any(), any());
 
             Assertions.assertThatThrownBy(() -> {
                 tagService.setTag(TagRequest.builder()

--- a/src/test/java/com/wnis/linkyway/service/tag/TagServiceLogicTest.java
+++ b/src/test/java/com/wnis/linkyway/service/tag/TagServiceLogicTest.java
@@ -31,11 +31,11 @@ public class TagServiceLogicTest {
     class AddTagTest {
 
         @ParameterizedTest
-        @CsvSource(value = { "fire,false,1", "hello21,true,1", ",,1" })
+        @CsvSource(value = { "fire,false,1", "hello21,true,1", "hello32,false,1" })
         void addTagSuccessTest(String tagName, String shareable, Long memberId) {
             TagRequest tagRequest = TagRequest.builder()
                                               .tagName(tagName)
-                                              .shareable(shareable)
+                                              .isPublic(shareable)
                                               .build();
             TagResponse tagResponse = tagService.addTag(tagRequest, memberId);
             logger.info("tagId: {}, tagName: {}", tagResponse.getTagId(), tagResponse.getTagName());
@@ -51,7 +51,7 @@ public class TagServiceLogicTest {
         void addTagSuccessTest(String tagName, String shareable, Long tagId) {
             TagRequest tagRequest = TagRequest.builder()
                                               .tagName(tagName)
-                                              .shareable(shareable)
+                                              .isPublic(shareable)
                                               .build();
             TagResponse tagResponse = tagService.setTag(tagRequest, tagId);
             logger.info("tagId: {}, tagName: {}", tagResponse.getTagId(), tagResponse.getTagName());


### PR DESCRIPTION
# 특이사항

- name 인덱스 설정
- member_member_id, name, is_public => not null
- shareable => is_public
- tagRepository: memberId 와 name 서치 순서 변경.. 인덱스 적용 시 카디널리티가 높을 순으로 배열을 통해 성능 향상