### PR TITLE
Feat/#82/search social tag

### DIFF
--- a/src/main/java/com/wnis/linkyway/controller/PackageController.java
+++ b/src/main/java/com/wnis/linkyway/controller/PackageController.java
@@ -1,0 +1,29 @@
+package com.wnis.linkyway.controller;
+
+import com.wnis.linkyway.dto.PackageResponse;
+import com.wnis.linkyway.dto.Response;
+import com.wnis.linkyway.service.PackageService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
+
+@RestController
+@RequestMapping("api/search")
+@RequiredArgsConstructor
+public class PackageController {
+
+    private final PackageService packageService;
+    
+    @GetMapping("/social/{tagName}")
+    ResponseEntity<Response> searchSocialByTagName(@RequestParam(value = "tagName") String tagName) {
+        List<PackageResponse> allPackageByTagName = packageService.findAllPackageByTagName(tagName);
+        return ResponseEntity.ok(Response.of(HttpStatus.OK, allPackageByTagName, "개인 검색 성공"));
+    }
+    
+}

--- a/src/main/java/com/wnis/linkyway/controller/PackageController.java
+++ b/src/main/java/com/wnis/linkyway/controller/PackageController.java
@@ -6,10 +6,7 @@ import com.wnis.linkyway.service.PackageService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestParam;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
 
@@ -21,7 +18,7 @@ public class PackageController {
     private final PackageService packageService;
     
     @GetMapping("/social/{tagName}")
-    ResponseEntity<Response> searchSocialByTagName(@RequestParam(value = "tagName") String tagName) {
+    ResponseEntity<Response> searchSocialByTagName(@PathVariable(value = "tagName") String tagName) {
         List<PackageResponse> allPackageByTagName = packageService.findAllPackageByTagName(tagName);
         return ResponseEntity.ok(Response.of(HttpStatus.OK, allPackageByTagName, "개인 검색 성공"));
     }

--- a/src/main/java/com/wnis/linkyway/dto/PackageDto.java
+++ b/src/main/java/com/wnis/linkyway/dto/PackageDto.java
@@ -5,7 +5,7 @@ import lombok.*;
 @Getter
 @Builder
 @NoArgsConstructor
-@AllArgsConstructor(access = AccessLevel.PRIVATE)
+@AllArgsConstructor
 public class PackageDto {
     
     private Long memberId;

--- a/src/main/java/com/wnis/linkyway/dto/PackageDto.java
+++ b/src/main/java/com/wnis/linkyway/dto/PackageDto.java
@@ -1,0 +1,16 @@
+package com.wnis.linkyway.dto;
+
+import lombok.*;
+
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+public class PackageDto {
+    
+    private Long memberId;
+    private String nickname;
+    private Long tagId;
+    private String tagName;
+    
+}

--- a/src/main/java/com/wnis/linkyway/dto/PackageResponse.java
+++ b/src/main/java/com/wnis/linkyway/dto/PackageResponse.java
@@ -14,5 +14,5 @@ public class PackageResponse {
     private String nickname;
     private Long tagId;
     private String tagName;
-    private Long numberOfCard;
+    private Integer numberOfCard;
 }

--- a/src/main/java/com/wnis/linkyway/dto/PackageResponse.java
+++ b/src/main/java/com/wnis/linkyway/dto/PackageResponse.java
@@ -1,0 +1,18 @@
+package com.wnis.linkyway.dto;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import lombok.*;
+
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public class PackageResponse {
+    
+    private Long memberId;
+    private String nickname;
+    private Long tagId;
+    private String tagName;
+    private Long numberOfCard;
+}

--- a/src/main/java/com/wnis/linkyway/repository/CardTagRepository.java
+++ b/src/main/java/com/wnis/linkyway/repository/CardTagRepository.java
@@ -1,5 +1,6 @@
 package com.wnis.linkyway.repository;
 
+import com.wnis.linkyway.dto.PackageDto;
 import com.wnis.linkyway.dto.tag.TagResponse;
 import com.wnis.linkyway.entity.CardTag;
 import org.springframework.data.jpa.repository.JpaRepository;
@@ -29,4 +30,10 @@ public interface CardTagRepository extends JpaRepository<CardTag, Long> {
     @Query("select ct.id from CardTag ct join ct.tag t " +
             "where t.id in :tagIdSet")
     List<Long> findAllCardTagIdInTagSet(@Param(value = "tagIdSet") Set<Long> tagIdSet);
+    
+    
+    @Query("select new com.wnis.linkyway.dto.PackageDto(m.id, m.nickname, t.id, t.name) from CardTag ct join ct.tag t " +
+            "join t.member m " +
+            "where t.name like %tagName%")
+    List<PackageDto> findAllPackageDtoByTagName(@Param(value = "tagName") String tagName);
 }

--- a/src/main/java/com/wnis/linkyway/repository/CardTagRepository.java
+++ b/src/main/java/com/wnis/linkyway/repository/CardTagRepository.java
@@ -34,6 +34,6 @@ public interface CardTagRepository extends JpaRepository<CardTag, Long> {
     
     @Query("select new com.wnis.linkyway.dto.PackageDto(m.id, m.nickname, t.id, t.name) from CardTag ct join ct.tag t " +
             "join t.member m " +
-            "where t.name like %tagName%")
+            "where t.name like %:tagName%")
     List<PackageDto> findAllPackageDtoByTagName(@Param(value = "tagName") String tagName);
 }

--- a/src/main/java/com/wnis/linkyway/service/PackageService.java
+++ b/src/main/java/com/wnis/linkyway/service/PackageService.java
@@ -1,0 +1,53 @@
+package com.wnis.linkyway.service;
+
+import com.wnis.linkyway.dto.PackageDto;
+import com.wnis.linkyway.dto.PackageResponse;
+import com.wnis.linkyway.repository.CardTagRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+@Service
+@RequiredArgsConstructor
+public class PackageService {
+    
+    private final CardTagRepository cardTagRepository;
+    
+    public List<PackageResponse> findAllPackageByTagName(String tagName) {
+        
+        List<PackageDto> packageDtoList = cardTagRepository.findAllPackageDtoByTagName(tagName);
+        Map<Long, Map<Long, List<PackageDto>>> map = packageDtoList.stream()
+                                                                   .collect(Collectors.groupingBy(
+                                                                               PackageDto::getMemberId,
+                                                                               Collectors.groupingBy(
+                                                                                       PackageDto::getTagId)));
+        
+        
+        
+        return manufacturePackageDtoMapToPackageResponse(map);
+    }
+    
+    
+    private List<PackageResponse>  manufacturePackageDtoMapToPackageResponse(Map<Long, Map<Long, List<PackageDto>>> map) {
+        List<PackageResponse> response = new ArrayList<>();
+    
+        for (Map.Entry<Long, Map<Long, List<PackageDto>>> firstEntry : map.entrySet()) {
+            for (Map.Entry<Long, List<PackageDto>> secondEntry : firstEntry.getValue().entrySet()) {
+                List<PackageDto> items = secondEntry.getValue();
+                PackageResponse packageResponse = PackageResponse.builder()
+                                                                 .memberId(firstEntry.getKey())
+                                                                 .nickname(items.get(0).getNickname())
+                                                                 .tagId(secondEntry.getKey())
+                                                                 .tagName(items.get(0).getTagName())
+                                                                 .numberOfCard(items.size())
+                                                                 .build();
+                response.add(packageResponse);
+            }
+        }
+        return response;
+    }
+}

--- a/src/test/java/com/wnis/linkyway/controller/PackageControllerTest.java
+++ b/src/test/java/com/wnis/linkyway/controller/PackageControllerTest.java
@@ -1,0 +1,76 @@
+package com.wnis.linkyway.controller;
+
+import com.wnis.linkyway.dto.PackageDto;
+import com.wnis.linkyway.dto.PackageResponse;
+import com.wnis.linkyway.service.PackageService;
+import org.apache.http.client.methods.RequestBuilder;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.context.annotation.ComponentScan;
+import org.springframework.context.annotation.FilterType;
+import org.springframework.security.config.annotation.web.configuration.WebSecurityConfigurerAdapter;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+import org.springframework.web.context.WebApplicationContext;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doReturn;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@WebMvcTest(controllers = PackageController.class,
+        excludeFilters = { @ComponentScan.Filter(type = FilterType.ASSIGNABLE_TYPE,
+                classes = WebSecurityConfigurerAdapter.class) })
+class PackageControllerTest {
+    
+    private final Logger logger = LoggerFactory.getLogger(this.getClass());
+    
+    @MockBean PackageService packageService;
+    
+    @Autowired MockMvc mockMvc;
+    
+    @Autowired WebApplicationContext ctx;
+    
+    @BeforeEach
+    void setUp() {
+        mockMvc = MockMvcBuilders.webAppContextSetup(ctx)
+                                 .alwaysDo(print())
+                                 .build();
+    }
+    
+    
+    @Test
+    @DisplayName("displayName")
+    void ControllerTest() throws Exception {
+        PackageResponse packageResponse = PackageResponse.builder()
+                .memberId(1L)
+                .tagId(1L)
+                .nickname("hello")
+                .tagName("t1")
+                .numberOfCard(10)
+                .build();
+        List<PackageResponse> responseList = new ArrayList<>();
+        responseList.add(packageResponse);
+        doReturn(responseList).when(packageService).findAllPackageByTagName(any());
+        
+        mockMvc.perform(get("/api/search/social/hello"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$..memberId").isNotEmpty())
+                .andExpect(jsonPath("$..nickname").isNotEmpty())
+                .andExpect(jsonPath("$..numberOfCard").isNotEmpty())
+                .andExpect(jsonPath("$..tagName").isNotEmpty())
+                .andExpect(jsonPath("$..tagId").isNotEmpty());
+    }
+}

--- a/src/test/java/com/wnis/linkyway/repository/CardTagRepositoryTest.java
+++ b/src/test/java/com/wnis/linkyway/repository/CardTagRepositoryTest.java
@@ -1,5 +1,6 @@
 package com.wnis.linkyway.repository;
 
+import com.wnis.linkyway.dto.PackageDto;
 import com.wnis.linkyway.dto.tag.TagResponse;
 import com.wnis.linkyway.entity.*;
 import org.junit.jupiter.api.BeforeEach;
@@ -14,13 +15,10 @@ import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
 import org.springframework.test.context.jdbc.Sql;
 
 import javax.persistence.EntityManager;
-
-import java.util.Arrays;
 import java.util.List;
 import java.util.Set;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.jupiter.api.Assertions.*;
 
 
 @DataJpaTest
@@ -133,11 +131,11 @@ class CardTagRepositoryTest {
     }
     
     @Nested
-    @DisplayName("findAllTagResponseByCardId 응답 테스트")
+    @DisplayName("findAllTagResponseByCardId 테스트")
     class findAllTagResponseByCardIdTest {
         
         @Test
-        @DisplayName("List<TagResponse> 리턴 테스트")
+        @DisplayName("List<TagResponse> 응답 테스트")
         void shouldReturnTagResponseTest() {
             List<TagResponse> tags = cardTagRepository.findAllTagResponseByCardId(1L);
             tags.forEach(tagResponse -> {
@@ -147,6 +145,20 @@ class CardTagRepositoryTest {
                             tagResponse.getIsPublic());
             });
             
+        }
+    }
+    
+    @Nested
+    @DisplayName("findAllPackageDtoByTagName 테스트")
+    class findAllPackageDtoByTagName {
+        
+        @Test
+        @DisplayName("응답 테스트")
+        void shouldReturnListPackageDtoTest() {
+            List<PackageDto> packageDtoList = cardTagRepository.findAllPackageDtoByTagName("t1");
+            assertThat(packageDtoList).isNotEmpty();
+            assertThat(packageDtoList.get(0)).extracting("tagName").isEqualTo("t1");
+            assertThat(packageDtoList.get(0)).extracting("nickname").isEqualTo("hello");
         }
     }
     

--- a/src/test/java/com/wnis/linkyway/service/PackageServiceTest.java
+++ b/src/test/java/com/wnis/linkyway/service/PackageServiceTest.java
@@ -1,0 +1,47 @@
+package com.wnis.linkyway.service;
+
+import com.wnis.linkyway.dto.PackageResponse;
+import com.wnis.linkyway.repository.CardTagRepository;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.test.context.jdbc.Sql;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@DataJpaTest
+@AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
+@Import({PackageService.class})
+@Sql("/sqltest/card-test.sql")
+public class PackageServiceTest {
+
+    private Logger logger = LoggerFactory.getLogger(this.getClass());
+    
+    @Autowired CardTagRepository cardTagRepository;
+    @Autowired PackageService packageService;
+    
+    @Test
+    @DisplayName("findAllPackageByTagNameTest")
+    void findAllPackageByTagNameTest() {
+    
+        List<PackageResponse> java = packageService.findAllPackageByTagName("java");
+        java.forEach(packageResponse -> {
+            assertThat(packageResponse).extracting("tagName").isEqualTo("java");
+        });
+    
+        // 조회시는 대소문자 구분 없이 모두 조회
+        List<PackageResponse> food = packageService.findAllPackageByTagName("FoOd");
+        logger.info("{}", food.get(0).getNumberOfCard());
+        assertThat(food.get(0).getNumberOfCard()).isEqualTo(4);
+        food.forEach(packageResponse -> {
+            assertThat(packageResponse).extracting("tagName").isEqualTo("food");
+        });
+    }
+}


### PR DESCRIPTION
# 특이사항

- 태그네임으로 검색하는 기반 소셜 검색 구현
- api/search/social/{tagName}
- 카드 태그 테이블로부터 tagName으로 조회해온 뒤 GroupBy를 이용해 구현
- 응답 Dto, Service 중간에 활용할 Dto 추가