### PR TITLE
이메일 인증 코드 전송 기능 구현

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -36,3 +36,7 @@ out/
 ### VS Code ###
 .vscode/
 src/main/java/com/wnis/linkyway/LinkywayApplication.java
+
+### properties
+
+email.yml

--- a/build.gradle
+++ b/build.gradle
@@ -62,6 +62,8 @@ dependencies {
     // test with time-sleep
     testImplementation group: 'org.awaitility', name: 'awaitility', version: '4.1.1'
 
+    // email
+    implementation 'org.springframework.boot:spring-boot-starter-mail'
 }
 
 tasks.named('test') {

--- a/src/main/java/com/wnis/linkyway/controller/EmailController.java
+++ b/src/main/java/com/wnis/linkyway/controller/EmailController.java
@@ -1,0 +1,35 @@
+package com.wnis.linkyway.controller;
+
+import com.wnis.linkyway.dto.Response;
+import com.wnis.linkyway.dto.email.EmailCodeRequest;
+import com.wnis.linkyway.service.email.EmailService;
+import com.wnis.linkyway.validation.ValidationSequence;
+import io.swagger.annotations.ApiOperation;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/email")
+@RequiredArgsConstructor
+public class EmailController {
+
+    private final EmailService emailService;
+
+    @PostMapping("/code")
+    @ApiOperation(value = "이메일 인증 코드 전송")
+    public ResponseEntity<Response<Object>> sendEmailVerificationCode(
+            @Validated(ValidationSequence.class) @RequestBody EmailCodeRequest codeRequest) {
+        emailService.sendVerificationCode(codeRequest.getEmail());
+        return ResponseEntity.ok(Response.builder()
+                .code(HttpStatus.OK.value())
+                .message("이메일로 인증코드를 전송했습니다.")
+                .build());
+    }
+
+}

--- a/src/main/java/com/wnis/linkyway/dto/email/EmailCodeRequest.java
+++ b/src/main/java/com/wnis/linkyway/dto/email/EmailCodeRequest.java
@@ -1,0 +1,24 @@
+package com.wnis.linkyway.dto.email;
+
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import javax.validation.constraints.NotBlank;
+import javax.validation.constraints.Pattern;
+
+import static com.wnis.linkyway.validation.ValidationGroup.*;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+@AllArgsConstructor
+public class EmailCodeRequest {
+
+    @NotBlank(message = "이메일을 입력해주세요", groups = NotBlankGroup.class)
+    @Pattern(regexp = "^[a-zA-Z\\d]+@[a-zA-Z0-9-]+\\.[a-zA-Z0-9-.]+$",
+            message = "이메일 형식을 확인해주세요",
+            groups = PatternCheckGroup.class)
+    private String email;
+
+}

--- a/src/main/java/com/wnis/linkyway/exception/common/EmailSendException.java
+++ b/src/main/java/com/wnis/linkyway/exception/common/EmailSendException.java
@@ -1,0 +1,11 @@
+package com.wnis.linkyway.exception.common;
+
+import com.wnis.linkyway.exception.error.ErrorCode;
+
+public class EmailSendException extends BusinessException {
+
+    public EmailSendException(String message) {
+        super(ErrorCode.EMAIL_SEND_ERROR, message);
+    }
+
+}

--- a/src/main/java/com/wnis/linkyway/exception/error/ErrorCode.java
+++ b/src/main/java/com/wnis/linkyway/exception/error/ErrorCode.java
@@ -8,6 +8,7 @@ public enum ErrorCode {
     // 4xx
     INVALID_INPUT_VALUE(400, "올바르지 않은 입력 요청"),
     INVALID_TYPE_VALUE(400, "올바르지 않은 타입 요청"),
+    EMAIL_SEND_ERROR(400, "메일 전송 오류"),
     RESOURCE_NOT_FOUND(404, "존재하지 않는 리소스 요청"),
     UNAUTHORIZED(401, "인증 자격 없음"),
     FORBIDDEN(403, "요청 거절됨"),

--- a/src/main/java/com/wnis/linkyway/redis/RedisProvider.java
+++ b/src/main/java/com/wnis/linkyway/redis/RedisProvider.java
@@ -7,6 +7,7 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.redis.core.StringRedisTemplate;
 import org.springframework.data.redis.core.ValueOperations;
 import org.springframework.stereotype.Component;
+import org.springframework.util.StringUtils;
 
 import java.time.Duration;
 
@@ -25,9 +26,8 @@ public class RedisProvider {
     public <T> T getData(String key, Class<T> classType) {
         try {
             ValueOperations<String, String> valueOperations = redisTemplate.opsForValue();
-            return objectMapper.readValue(valueOperations.get(key), classType);
-        }
-        catch (JsonProcessingException e) {
+            return getObjectData(valueOperations.get(key), classType);
+        } catch (JsonProcessingException e) {
             log.error("", e);
             return null;
         }
@@ -51,6 +51,13 @@ public class RedisProvider {
 
     public void deleteData(String key) {
         redisTemplate.delete(key);
+    }
+
+    private <T> T getObjectData(String values, Class<T> classType) throws JsonProcessingException {
+        if (!StringUtils.hasText(values)) {
+            return null;
+        }
+        return objectMapper.readValue(values, classType);
     }
 
 }

--- a/src/main/java/com/wnis/linkyway/redis/values/EmailVerificationValue.java
+++ b/src/main/java/com/wnis/linkyway/redis/values/EmailVerificationValue.java
@@ -1,0 +1,34 @@
+package com.wnis.linkyway.redis.values;
+
+import com.wnis.linkyway.exception.common.EmailSendException;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class EmailVerificationValue {
+
+    private static final int RETRY_COUNT = 5;
+
+    private int currentCount;
+    private String code;
+
+    public EmailVerificationValue() {
+        this.currentCount = 0;
+        this.code = "";
+    }
+
+    public void updateVerificationInfo(String code) {
+        checkRetryCount();
+        this.currentCount++;
+        this.code = code;
+    }
+
+    private void checkRetryCount() {
+        if (currentCount >= RETRY_COUNT) {
+            throw new EmailSendException(
+                    "연속 " + RETRY_COUNT + "회 인증 요청으로 일시적으로 메일 전송이 제한되었습니다. 잠시후 다시 시도해주세요");
+        }
+    }
+
+}

--- a/src/main/java/com/wnis/linkyway/service/email/EmailService.java
+++ b/src/main/java/com/wnis/linkyway/service/email/EmailService.java
@@ -1,0 +1,60 @@
+package com.wnis.linkyway.service.email;
+
+import com.wnis.linkyway.exception.common.EmailSendException;
+import com.wnis.linkyway.redis.RedisProvider;
+import com.wnis.linkyway.redis.values.EmailVerificationValue;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.mail.MailException;
+import org.springframework.mail.SimpleMailMessage;
+import org.springframework.mail.javamail.JavaMailSender;
+import org.springframework.stereotype.Service;
+
+import java.util.Optional;
+import java.util.UUID;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class EmailService {
+
+    private final JavaMailSender emailSender;
+    private final RedisProvider redisProvider;
+
+    private static final String VERIFICATION_SUBJECT = "LinkyWay 에서 이메일 인증코드 발송";
+    private static final long EMAIL_VALIDATION_EXPIRATION_TIME = 1000 * 60 * 15;
+
+    public void sendVerificationCode(String email) {
+        try {
+            EmailVerificationValue emailVerification = getEmailVerification(email);
+            emailVerification.updateVerificationInfo(createCode());
+            sendEmail(email, VERIFICATION_SUBJECT, setVerificationMailText(emailVerification.getCode()));
+            redisProvider.setDataWithExpiration(email, emailVerification, EMAIL_VALIDATION_EXPIRATION_TIME);
+        } catch (MailException e) {
+            log.error("", e);
+            throw new EmailSendException("알 수 없는 이유로 메일 전송에 실패했습니다");
+        }
+    }
+
+    public void sendEmail(String receiver, String subject, String text) throws MailException {
+        SimpleMailMessage message = new SimpleMailMessage();
+        message.setTo(receiver);
+        message.setSubject(subject);
+        message.setText(text);
+        emailSender.send(message);
+    }
+
+    private String setVerificationMailText(String code) {
+        return "인증번호: " + code;
+    }
+
+    private String createCode() {
+        return UUID.randomUUID().toString().split("-")[0];
+    }
+
+    private EmailVerificationValue getEmailVerification(String email) {
+        return Optional.ofNullable(redisProvider.getData(email, EmailVerificationValue.class))
+                .orElse(new EmailVerificationValue());
+    }
+
+}

--- a/src/test/java/com/wnis/linkyway/controller/email/EmailControllerTest.java
+++ b/src/test/java/com/wnis/linkyway/controller/email/EmailControllerTest.java
@@ -1,0 +1,55 @@
+package com.wnis.linkyway.controller.email;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.wnis.linkyway.controller.EmailController;
+import com.wnis.linkyway.dto.email.EmailCodeRequest;
+import com.wnis.linkyway.service.email.EmailService;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.mockito.BDDMockito;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.context.annotation.ComponentScan;
+import org.springframework.context.annotation.FilterType;
+import org.springframework.http.MediaType;
+import org.springframework.security.config.annotation.web.configuration.WebSecurityConfigurerAdapter;
+import org.springframework.test.web.servlet.MockMvc;
+
+import static org.mockito.BDDMockito.*;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@WebMvcTest(controllers = {EmailController.class},
+        excludeFilters = {@ComponentScan.Filter(type = FilterType.ASSIGNABLE_TYPE,
+                classes = WebSecurityConfigurerAdapter.class)})
+@AutoConfigureMockMvc(addFilters = false)
+class EmailControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    @MockBean
+    private EmailService emailService;
+
+    private final String API = "/api/email";
+    private final String EMAIL = "ehd0309@naver.com";
+    @Test
+    @DisplayName("이메일 인증 코드 전송 응답 테스트")
+    void sendEmailVerificationCodeTest() throws Exception {
+        EmailCodeRequest emailCodeRequest = new EmailCodeRequest(EMAIL);
+
+        mockMvc.perform(post(API + "/code")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(emailCodeRequest)))
+                .andExpect(status().isOk())
+                .andDo(print());
+        verify(emailService).sendVerificationCode(EMAIL);
+    }
+
+}

--- a/src/test/java/com/wnis/linkyway/redis/RedisProviderTest.java
+++ b/src/test/java/com/wnis/linkyway/redis/RedisProviderTest.java
@@ -35,6 +35,13 @@ class RedisProviderTest {
     }
 
     @Test
+    @DisplayName("없는 객체 데이터에 대한 조회 요청에 대해 null 을 반환한다.")
+    void findObjectValueByKeyAndTypeNotExistsShouldReturnNull() {
+        SampleObj result = redisProvider.getData("hello", SampleObj.class);
+        assertThat(result).isNull();
+    }
+
+    @Test
     @DisplayName("저장된 객체 key-value 데이터를 조회할 수 있다.")
     void findObjectValueByKeyAndTypeShouldReturnObjectResult() {
         SampleObj result = redisProvider.getData(objectKey, SampleObj.class);
@@ -82,10 +89,6 @@ class RedisProviderTest {
 
         public String getName() {
             return name;
-        }
-
-        public int getAge() {
-            return age;
         }
 
     }

--- a/src/test/java/com/wnis/linkyway/redis/values/EmailVerificationValueTest.java
+++ b/src/test/java/com/wnis/linkyway/redis/values/EmailVerificationValueTest.java
@@ -1,0 +1,39 @@
+package com.wnis.linkyway.redis.values;
+
+import com.wnis.linkyway.exception.common.EmailSendException;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.*;
+
+class EmailVerificationValueTest {
+
+
+    @Nested
+    @DisplayName("이메일 인증 정보 갱신 테스트")
+    class EmailVerificationUpdateTest {
+
+        private static final int RETRY_COUNT = 5;
+        private static final String CODE = "code";
+
+        @Test
+        @DisplayName("이메일 인증 정보를 성공적으로 갱신")
+        void updateRequestShouldSuccess() {
+            EmailVerificationValue emailVerificationValue = new EmailVerificationValue();
+            emailVerificationValue.updateVerificationInfo(CODE);
+            assertThat(emailVerificationValue.getCurrentCount()).isEqualTo(1);
+            assertThat(emailVerificationValue.getCode()).isEqualTo(CODE);
+        }
+
+        @Test
+        @DisplayName("제한 횟수 초과로 이메일 인증 정보 갱신 요청은 예외를 반환")
+        void updateRequestThrowsEmailSendExceptionWithExceededRetryCountLimit() {
+            EmailVerificationValue emailVerificationValue =
+                    new EmailVerificationValue(RETRY_COUNT, CODE);
+            assertThatThrownBy(()-> emailVerificationValue.updateVerificationInfo("newCode"))
+                    .isInstanceOf(EmailSendException.class);
+        }
+
+    }
+}

--- a/src/test/java/com/wnis/linkyway/service/email/EmailServiceTest.java
+++ b/src/test/java/com/wnis/linkyway/service/email/EmailServiceTest.java
@@ -1,0 +1,77 @@
+package com.wnis.linkyway.service.email;
+
+import com.wnis.linkyway.exception.common.EmailSendException;
+import com.wnis.linkyway.redis.RedisProvider;
+import com.wnis.linkyway.redis.values.EmailVerificationValue;
+import org.junit.jupiter.api.*;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+
+import org.mockito.MockitoAnnotations;
+import org.springframework.mail.SimpleMailMessage;
+import org.springframework.mail.javamail.JavaMailSender;
+
+import static org.assertj.core.api.Assertions.*;
+import static org.mockito.BDDMockito.*;
+
+class EmailServiceTest {
+
+    @InjectMocks
+    private EmailService emailService;
+
+    @Mock
+    private RedisProvider redisProvider;
+
+    @Mock
+    private JavaMailSender javaMailSender;
+
+    private final String EMAIL = "ehd0309@naver.com";
+
+    @BeforeEach
+    void initMocks() {
+        MockitoAnnotations.openMocks(this);
+    }
+
+    @Test
+    @DisplayName("이메일 전송 요청 시 이메일 전송 메소드가 동작해야 한다.")
+    void sendEmailRequestShouldDoSendEmailOfJavaEmailSender() throws Exception {
+        emailService.sendEmail(EMAIL, "제목", "보낼 내용");
+        verify(javaMailSender).send(any(SimpleMailMessage.class));
+    }
+
+    @Nested
+    @DisplayName("인증 코드 메일 전송 테스트")
+    class SendVerificationCodeTest {
+
+        @Test
+        @DisplayName("첫 인증 요청자를 대상으로 정상적으로 인증 코드를 발송한다.")
+        void SendEmailRequestFirstTimeShouldDoSendEmail() throws Exception {
+            emailService.sendVerificationCode(EMAIL);
+            verify(javaMailSender).send(any(SimpleMailMessage.class));
+        }
+
+        @Test
+        @DisplayName("이미 인증했던 요청자를 대상으로 정상적으로 인증 코드를 재발송한다.")
+        void SendEmailRequestShouldDoSendEmail() throws Exception {
+            EmailVerificationValue emailVerificationValue =
+                    new EmailVerificationValue(3, "CODE");
+            given(redisProvider.getData(EMAIL, EmailVerificationValue.class))
+                    .willReturn(emailVerificationValue);
+            emailService.sendVerificationCode(EMAIL);
+            assertThat(emailVerificationValue.getCurrentCount()).isEqualTo(4);
+            assertThat(emailVerificationValue.getCode()).isNotEqualTo("CODE");
+        }
+
+        @Test
+        @DisplayName("인증 횟수를 초과한 요청자를 대상으로 예외를 발생하고 인증 코드를 발송하지 않는다")
+        void SendEmailRequestWithExceededCountShouldThrowsEmailSendException() throws Exception {
+            EmailVerificationValue emailVerificationValue =
+                    new EmailVerificationValue(999, "CODE");
+            given(redisProvider.getData(EMAIL, EmailVerificationValue.class))
+                    .willReturn(emailVerificationValue);
+            assertThatThrownBy(() -> emailService.sendVerificationCode(EMAIL))
+                    .isInstanceOf(EmailSendException.class);
+        }
+    }
+
+}


### PR DESCRIPTION
### 추가사항

**의존성**

```
    implementation 'org.springframework.boot:spring-boot-starter-mail'
```

<br>

**프로퍼티**

버전관리 제외 처리 해두었고 로컬에서는 각자 상황에 맞게 넣어서 사용하시면 됩니다

> email.yml

```
spring:
  mail:
    host: smtp.gmail.com
    port: 587
    username: [당신의 구글 이메일]
    password: [발급한 특수 비밀번호]
    properties:
      mail:
        smtp:
          auth: true
          starttls:
            enable: true
```

<br>


**인증 코드 전송 기능**

- 사용자가 이메일로 인증 코드 전송을 요청하면 보내준다.
 
- redis에 이메일 코드 전송 기록을 저장

- 최근 15분간 5회 전송 요청했을 경우 요청이 제한된다.

<br>

**특이사항**

- 과연 api 네이밍이 적절한가?  ; `POST: /api/email/code`

- 이메일 전송 관련 규칙 프로퍼티로 분리하는 것을 고려해보자