### PR TITLE
이메일 검증 기능 구현

### DIFF
--- a/src/main/java/com/wnis/linkyway/aop/EmailVerificationAspect.java
+++ b/src/main/java/com/wnis/linkyway/aop/EmailVerificationAspect.java
@@ -1,0 +1,80 @@
+package com.wnis.linkyway.aop;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.wnis.linkyway.exception.common.EmailSendException;
+import com.wnis.linkyway.util.cookie.CookieUtil;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.aspectj.lang.ProceedingJoinPoint;
+import org.aspectj.lang.annotation.Around;
+import org.aspectj.lang.annotation.Aspect;
+import org.aspectj.lang.annotation.Pointcut;
+import org.springframework.boot.configurationprocessor.json.JSONException;
+import org.springframework.boot.configurationprocessor.json.JSONObject;
+import org.springframework.stereotype.Component;
+
+import javax.servlet.http.Cookie;
+import javax.servlet.http.HttpServletRequest;
+
+import static com.wnis.linkyway.util.cookie.CookieConstants.*;
+
+
+@Slf4j
+@Aspect
+@Component
+@RequiredArgsConstructor
+public class EmailVerificationAspect {
+
+    private final CookieUtil cookieUtil;
+    private final HttpServletRequest httpServletRequest;
+    private final ObjectMapper objectMapper;
+
+    @Pointcut("@annotation(com.wnis.linkyway.aop.WithEmailVerification)")
+    public void withEmailVerification() {
+    }
+
+    @Around(
+            "withEmailVerification() && " +
+                    "execution(* *())"
+    )
+    public Object simpleProcessWithoutParameters(ProceedingJoinPoint joinPoint) throws Throwable {
+        return joinPoint.proceed();
+    }
+
+    @Around(
+            "withEmailVerification() && " +
+                    "execution(* *(@org.springframework.web.bind.annotation.RequestBody (*), ..)) && " +
+                    "args(body, ..)"
+    )
+    public Object processWithBody(ProceedingJoinPoint joinPoint, Object body) throws Throwable {
+        Cookie cookie = cookieUtil.getCookieByCookieName(httpServletRequest, VERIFICATION_COOKIE_NAME);
+        checkCookieExists(cookie);
+        checkRequestEmailEqualsWithCookie(cookie, body);
+        return joinPoint.proceed();
+    }
+
+    private void checkRequestEmailEqualsWithCookie(Cookie cookie, Object body) {
+        try {
+            String email = getValueOfKeyFromBodyRequest("email", body);
+            if (!cookie.getValue().equals(email)) {
+                throw new EmailSendException("이메일 정보가 올바르지 않습니다");
+            }
+        } catch (JsonProcessingException | JSONException e) {
+            log.error("", e);
+            throw new EmailSendException("요청 데이터로부터 이메일 정보를 얻을 수 없음");
+        }
+    }
+
+    private String getValueOfKeyFromBodyRequest(String key, Object body) throws JsonProcessingException, JSONException {
+        JSONObject jsonObject = new JSONObject(objectMapper.writeValueAsString(body));
+        return jsonObject.getString(key);
+    }
+
+    private void checkCookieExists(Cookie cookie) {
+        if (cookie == null) {
+            throw new EmailSendException("이메일 인증이 필요한 요청입니다.");
+        }
+    }
+
+}

--- a/src/main/java/com/wnis/linkyway/aop/WithEmailVerification.java
+++ b/src/main/java/com/wnis/linkyway/aop/WithEmailVerification.java
@@ -1,0 +1,11 @@
+package com.wnis.linkyway.aop;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target({ElementType.METHOD})
+@Retention(RetentionPolicy.RUNTIME)
+public @interface WithEmailVerification {
+}

--- a/src/main/java/com/wnis/linkyway/controller/EmailController.java
+++ b/src/main/java/com/wnis/linkyway/controller/EmailController.java
@@ -2,7 +2,9 @@ package com.wnis.linkyway.controller;
 
 import com.wnis.linkyway.dto.Response;
 import com.wnis.linkyway.dto.email.EmailCodeRequest;
+import com.wnis.linkyway.dto.email.EmailConfirmRequest;
 import com.wnis.linkyway.service.email.EmailService;
+import com.wnis.linkyway.util.cookie.CookieUtil;
 import com.wnis.linkyway.validation.ValidationSequence;
 import io.swagger.annotations.ApiOperation;
 import lombok.RequiredArgsConstructor;
@@ -14,12 +16,19 @@ import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
+import javax.servlet.http.Cookie;
+import javax.servlet.http.HttpServletResponse;
+
 @RestController
 @RequestMapping("/api/email")
 @RequiredArgsConstructor
 public class EmailController {
 
     private final EmailService emailService;
+    private final CookieUtil cookieUtil;
+
+    private static final int VERIFICATION_COOKIE_EXPIRATION_MINUTE = 10;
+    private static final String VERIFICATION_COOKIE_NAME = "evc";
 
     @PostMapping("/code")
     @ApiOperation(value = "이메일 인증 코드 전송")
@@ -29,6 +38,23 @@ public class EmailController {
         return ResponseEntity.ok(Response.builder()
                 .code(HttpStatus.OK.value())
                 .message("이메일로 인증코드를 전송했습니다.")
+                .build());
+    }
+
+    @PostMapping("/confirm")
+    @ApiOperation(value = "이메일 인증 코드 검증")
+    public ResponseEntity<Response<Object>> verifyEmailCode(
+            HttpServletResponse response,
+            @Validated(ValidationSequence.class) @RequestBody EmailConfirmRequest codeRequest) {
+        emailService.confirmVerificationCode(codeRequest.getEmail(), codeRequest.getCode());
+        Cookie cookie = cookieUtil.createCookie(
+                VERIFICATION_COOKIE_NAME,
+                codeRequest.getEmail(),
+                VERIFICATION_COOKIE_EXPIRATION_MINUTE);
+        response.addCookie(cookie);
+        return ResponseEntity.ok(Response.builder()
+                .code(HttpStatus.OK.value())
+                .message("이메일 인증 성공")
                 .build());
     }
 

--- a/src/main/java/com/wnis/linkyway/controller/EmailController.java
+++ b/src/main/java/com/wnis/linkyway/controller/EmailController.java
@@ -19,6 +19,8 @@ import org.springframework.web.bind.annotation.RestController;
 import javax.servlet.http.Cookie;
 import javax.servlet.http.HttpServletResponse;
 
+import static com.wnis.linkyway.util.cookie.CookieConstants.*;
+
 @RestController
 @RequestMapping("/api/email")
 @RequiredArgsConstructor
@@ -26,9 +28,6 @@ public class EmailController {
 
     private final EmailService emailService;
     private final CookieUtil cookieUtil;
-
-    private static final int VERIFICATION_COOKIE_EXPIRATION_MINUTE = 10;
-    private static final String VERIFICATION_COOKIE_NAME = "evc";
 
     @PostMapping("/code")
     @ApiOperation(value = "이메일 인증 코드 전송")

--- a/src/main/java/com/wnis/linkyway/controller/MemberController.java
+++ b/src/main/java/com/wnis/linkyway/controller/MemberController.java
@@ -1,5 +1,6 @@
 package com.wnis.linkyway.controller;
 
+import com.wnis.linkyway.aop.WithEmailVerification;
 import com.wnis.linkyway.dto.Response;
 import com.wnis.linkyway.dto.member.*;
 import com.wnis.linkyway.security.annotation.Authenticated;
@@ -20,6 +21,7 @@ public class MemberController {
     private final MemberService memberService;
     
     @PostMapping
+    @WithEmailVerification
     public ResponseEntity<Response> join(
             @Validated(ValidationSequence.class) @RequestBody JoinRequest joinRequest) {
         MemberResponse response = memberService.join(joinRequest);

--- a/src/main/java/com/wnis/linkyway/dto/email/EmailConfirmRequest.java
+++ b/src/main/java/com/wnis/linkyway/dto/email/EmailConfirmRequest.java
@@ -1,0 +1,27 @@
+package com.wnis.linkyway.dto.email;
+
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import javax.validation.constraints.NotBlank;
+import javax.validation.constraints.Pattern;
+
+import static com.wnis.linkyway.validation.ValidationGroup.*;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+@AllArgsConstructor
+public class EmailConfirmRequest {
+
+    @NotBlank(message = "이메일을 입력해주세요", groups = NotBlankGroup.class)
+    @Pattern(regexp = "^[a-zA-Z\\d]+@[a-zA-Z0-9-]+\\.[a-zA-Z0-9-.]+$",
+            message = "이메일 형식을 확인해주세요",
+            groups = PatternCheckGroup.class)
+    private String email;
+
+    @NotBlank(message = "인증 코드를 입력하세요", groups = NotBlankGroup.class)
+    private String code;
+
+}

--- a/src/main/java/com/wnis/linkyway/redis/values/EmailVerificationValue.java
+++ b/src/main/java/com/wnis/linkyway/redis/values/EmailVerificationValue.java
@@ -24,6 +24,12 @@ public class EmailVerificationValue {
         this.code = code;
     }
 
+    public void checkSameCode(String code) {
+        if (!this.code.equals(code)) {
+            throw new EmailSendException("잘못된 인증 코드입니다.");
+        }
+    }
+
     private void checkRetryCount() {
         if (currentCount >= RETRY_COUNT) {
             throw new EmailSendException(

--- a/src/main/java/com/wnis/linkyway/service/email/EmailService.java
+++ b/src/main/java/com/wnis/linkyway/service/email/EmailService.java
@@ -24,6 +24,15 @@ public class EmailService {
     private static final String VERIFICATION_SUBJECT = "LinkyWay 에서 이메일 인증코드 발송";
     private static final long EMAIL_VALIDATION_EXPIRATION_TIME = 1000 * 60 * 15;
 
+    public void confirmVerificationCode(String email, String code) {
+        EmailVerificationValue emailVerification = redisProvider.getData(email, EmailVerificationValue.class);
+        if (emailVerification == null) {
+            throw new EmailSendException("인증 코드 발송된 적 없음");
+        }
+        emailVerification.checkSameCode(code);
+        redisProvider.deleteData(email);
+    }
+
     public void sendVerificationCode(String email) {
         try {
             EmailVerificationValue emailVerification = getEmailVerification(email);

--- a/src/main/java/com/wnis/linkyway/util/cookie/CookieConstants.java
+++ b/src/main/java/com/wnis/linkyway/util/cookie/CookieConstants.java
@@ -1,0 +1,12 @@
+package com.wnis.linkyway.util.cookie;
+
+import lombok.AccessLevel;
+import lombok.NoArgsConstructor;
+
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+public class CookieConstants {
+
+    public static final int VERIFICATION_COOKIE_EXPIRATION_MINUTE = 10;
+    public static final String VERIFICATION_COOKIE_NAME = "evc";
+
+}

--- a/src/main/java/com/wnis/linkyway/util/cookie/CookieUtil.java
+++ b/src/main/java/com/wnis/linkyway/util/cookie/CookieUtil.java
@@ -19,8 +19,8 @@ public class CookieUtil {
                 .findFirst().orElse(null);
     }
 
-    public Cookie createCookie(String cookieName, String value, int second){
-        Cookie token = new Cookie(cookieName,value);
+    public Cookie createCookie(String cookieName, String value, int second) {
+        Cookie token = new Cookie(cookieName, value);
         token.setHttpOnly(true);
         token.setMaxAge(second);
         token.setPath("/");

--- a/src/main/java/com/wnis/linkyway/util/cookie/CookieUtil.java
+++ b/src/main/java/com/wnis/linkyway/util/cookie/CookieUtil.java
@@ -1,0 +1,29 @@
+package com.wnis.linkyway.util.cookie;
+
+import org.springframework.stereotype.Component;
+
+import javax.servlet.http.Cookie;
+import javax.servlet.http.HttpServletRequest;
+import java.util.Arrays;
+
+@Component
+public class CookieUtil {
+
+    public Cookie getCookieByCookieName(HttpServletRequest request, String name) {
+        Cookie[] cookies = request.getCookies();
+        if (cookies == null) {
+            return null;
+        }
+        return Arrays.stream(request.getCookies())
+                .filter(cookie -> name.equals(cookie.getName()))
+                .findFirst().orElse(null);
+    }
+
+    public Cookie createCookie(String cookieName, String value, int second){
+        Cookie token = new Cookie(cookieName,value);
+        token.setHttpOnly(true);
+        token.setMaxAge(second);
+        token.setPath("/");
+        return token;
+    }
+}

--- a/src/test/java/com/wnis/linkyway/controller/MemberControllerIntegrationTest.java
+++ b/src/test/java/com/wnis/linkyway/controller/MemberControllerIntegrationTest.java
@@ -5,6 +5,7 @@ import com.wnis.linkyway.controller.tag.TagControllerIntegrationTest;
 import com.wnis.linkyway.dto.member.JoinRequest;
 import com.wnis.linkyway.dto.member.PasswordRequest;
 import com.wnis.linkyway.security.testutils.WithMockMember;
+import com.wnis.linkyway.util.cookie.CookieConstants;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
@@ -21,6 +22,7 @@ import org.springframework.test.web.servlet.setup.MockMvcBuilders;
 import org.springframework.web.context.WebApplicationContext;
 import org.springframework.web.filter.CharacterEncodingFilter;
 
+import javax.servlet.http.Cookie;
 import javax.transaction.Transactional;
 
 import static org.springframework.security.test.web.servlet.setup.SecurityMockMvcConfigurers.springSecurity;
@@ -47,10 +49,10 @@ class MemberControllerIntegrationTest {
     void setup() {
         // MockMvc 설정
         mockMvc = MockMvcBuilders.webAppContextSetup(ctx)
-                                 .apply(springSecurity())
-                                 .addFilters(new CharacterEncodingFilter("UTF-8", true)) // 필터 추가
-                                 .alwaysDo(print())
-                                 .build();
+                .apply(springSecurity())
+                .addFilters(new CharacterEncodingFilter("UTF-8", true)) // 필터 추가
+                .alwaysDo(print())
+                .build();
     }
 
     @Nested
@@ -60,46 +62,48 @@ class MemberControllerIntegrationTest {
         @Test
         @DisplayName("응답 테스트")
         void responseTest() throws Exception {
+            Cookie cookie = new Cookie(CookieConstants.VERIFICATION_COOKIE_NAME, "marraas1101@naver.com");
             JoinRequest joinRequest = JoinRequest.builder()
-                                                 .email("marraas1101@naver.com")
-                                                 .password("aAa1212!32")
-                                                 .nickname("hello")
-                                                 .build();
-
-            MvcResult mvcResult = mockMvc.perform(post("/api/members").contentType("application/json")
-                                                                      .content(objectMapper.writeValueAsString(joinRequest)))
-                                         .andExpect(status().is(200))
-                                         .andReturn();
+                    .email("marraas1101@naver.com")
+                    .password("aAa1212!32")
+                    .nickname("hello")
+                    .build();
+            mockMvc.perform(post("/api/members")
+                    .cookie(cookie)
+                    .contentType("application/json")
+                    .content(objectMapper.writeValueAsString(joinRequest)))
+                    .andExpect(status().is(200))
+                    .andReturn();
         }
 
         @Test
         @DisplayName("유효성 핸들러 응답 테스트")
         void shouldThrowValidationExceptionResponseTest() throws Exception {
             JoinRequest joinRequest = JoinRequest.builder()
-                                                 .email("marraas1101@navaerom")
-                                                 .password("aAa1212!32")
-                                                 .nickname("hello")
-                                                 .build();
-
-            MvcResult mvcResult = mockMvc.perform(post("/api/members").contentType("application/json")
-                                                                      .content(objectMapper.writeValueAsString(joinRequest)))
-                                         .andExpect(status().is(400))
-                                         .andReturn();
+                    .email("marraas1101@navaerom")
+                    .password("aAa1212!32")
+                    .nickname("hello")
+                    .build();
+            mockMvc.perform(post("/api/members").contentType("application/json")
+                    .content(objectMapper.writeValueAsString(joinRequest)))
+                    .andExpect(status().is(400))
+                    .andReturn();
         }
 
         @Test
         @DisplayName("중복 예외 핸들러 응답 테스트")
         void shouldThrowDuplicateExceptionResponseTest() throws Exception {
+            Cookie cookie = new Cookie(CookieConstants.VERIFICATION_COOKIE_NAME, "marrin1101@naver.com");
             JoinRequest joinRequest = JoinRequest.builder()
-                                                 .email("marrin1101@naver.com")
-                                                 .password("aAa1212!32")
-                                                 .nickname("hello")
-                                                 .build();
-
-            MvcResult mvcResult = mockMvc.perform(post("/api/members").contentType("application/json")
-                                                                      .content(objectMapper.writeValueAsString(joinRequest)))
-                                         .andExpect(status().is(409))
-                                         .andReturn();
+                    .email("marrin1101@naver.com")
+                    .password("aAa1212!32")
+                    .nickname("hello")
+                    .build();
+            mockMvc.perform(post("/api/members").contentType("application/json")
+                    .cookie(cookie)
+                    .content(objectMapper.writeValueAsString(joinRequest)))
+                    .andExpect(status().is(409))
+                    .andReturn();
         }
 
     }
@@ -111,19 +115,18 @@ class MemberControllerIntegrationTest {
         @Test
         @DisplayName("응답 테스트")
         void responseTest() throws Exception {
-
-            MvcResult mvcResult = mockMvc.perform(get("/api/members/email?email=marrin1101@naver.com"))
-                                         .andExpect(status().is(200))
-                                         .andReturn();
+            mockMvc.perform(get("/api/members/email?email=marrin1101@naver.com"))
+                    .andExpect(status().is(200))
+                    .andReturn();
 
         }
 
         @Test
         @DisplayName("이메일이 없는 경우 조회 테스트")
         void shouldThrowNotFoundEmailExceptionResponseTest() throws Exception {
-            MvcResult mvcResult = mockMvc.perform(get("/api/members/email?email=marrin1101@naver1.com"))
-                                         .andExpect(status().is(404))
-                                         .andReturn();
+            mockMvc.perform(get("/api/members/email?email=marrin1101@naver1.com"))
+                    .andExpect(status().is(404))
+                    .andReturn();
 
         }
 
@@ -137,10 +140,9 @@ class MemberControllerIntegrationTest {
         @DisplayName("응답 테스트")
         @WithMockMember(id = 1L, email = "marrin1101@hanmail.com")
         void responseTest() throws Exception {
-
-            MvcResult mvcResult = mockMvc.perform(get("/api/members/page/me"))
-                                         .andExpect(status().is(200))
-                                         .andReturn();
+            mockMvc.perform(get("/api/members/page/me"))
+                    .andExpect(status().is(200))
+                    .andReturn();
 
         }
 
@@ -155,13 +157,13 @@ class MemberControllerIntegrationTest {
         @WithMockMember(id = 1L, email = "marrin1101@hanmail.com")
         void responseTest() throws Exception {
             PasswordRequest passwordRequest = PasswordRequest.builder()
-                                                             .password("asa!asd12324A")
-                                                             .build();
+                    .password("asa!asd12324A")
+                    .build();
 
-            MvcResult mvcResult = mockMvc.perform(put("/api/members/password").contentType("application/json")
-                                                                              .content(objectMapper.writeValueAsString(passwordRequest)))
-                                         .andExpect(status().is(200))
-                                         .andReturn();
+            mockMvc.perform(put("/api/members/password").contentType("application/json")
+                    .content(objectMapper.writeValueAsString(passwordRequest)))
+                    .andExpect(status().is(200))
+                    .andReturn();
 
         }
 
@@ -169,13 +171,13 @@ class MemberControllerIntegrationTest {
         @DisplayName("유효성 핸들러 응답 테스트")
         void shouldThrowValidationExceptionResponseTest() throws Exception {
             PasswordRequest passwordRequest = PasswordRequest.builder()
-                                                             .password("aaaaa")
-                                                             .build();
+                    .password("aaaaa")
+                    .build();
 
-            MvcResult mvcResult = mockMvc.perform(put("/api/members/password").contentType("application/json")
-                                                                              .content(objectMapper.writeValueAsString(passwordRequest)))
-                                         .andExpect(status().is(400))
-                                         .andReturn();
+            mockMvc.perform(put("/api/members/password").contentType("application/json")
+                    .content(objectMapper.writeValueAsString(passwordRequest)))
+                    .andExpect(status().is(400))
+                    .andReturn();
         }
 
     }
@@ -189,9 +191,9 @@ class MemberControllerIntegrationTest {
         @DisplayName("응답 테스트")
         @WithMockMember(id = 1L, email = "marrin1101@hanmail.com")
         void responseTest() throws Exception {
-            MvcResult mvcResult = mockMvc.perform(delete("/api/members"))
-                                         .andExpect(status().is(200))
-                                         .andReturn();
+            mockMvc.perform(delete("/api/members"))
+                    .andExpect(status().is(200))
+                    .andReturn();
         }
     }
 
@@ -203,8 +205,8 @@ class MemberControllerIntegrationTest {
         @DisplayName("응답 테스트")
         void responseTest() throws Exception {
             mockMvc.perform(get("/api/members/nickname").param("nickname", "Zeratu1"))
-                   .andExpect(status().isOk())
-                   .andDo(print());
+                    .andExpect(status().isOk())
+                    .andDo(print());
         }
     }
 

--- a/src/test/java/com/wnis/linkyway/controller/email/EmailControllerTest.java
+++ b/src/test/java/com/wnis/linkyway/controller/email/EmailControllerTest.java
@@ -3,10 +3,12 @@ package com.wnis.linkyway.controller.email;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.wnis.linkyway.controller.EmailController;
 import com.wnis.linkyway.dto.email.EmailCodeRequest;
+import com.wnis.linkyway.dto.email.EmailConfirmRequest;
 import com.wnis.linkyway.service.email.EmailService;
+import com.wnis.linkyway.util.cookie.CookieUtil;
+import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
-import org.mockito.BDDMockito;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
@@ -16,6 +18,9 @@ import org.springframework.context.annotation.FilterType;
 import org.springframework.http.MediaType;
 import org.springframework.security.config.annotation.web.configuration.WebSecurityConfigurerAdapter;
 import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.MvcResult;
+
+import javax.servlet.http.Cookie;
 
 import static org.mockito.BDDMockito.*;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
@@ -37,8 +42,12 @@ class EmailControllerTest {
     @MockBean
     private EmailService emailService;
 
+    @MockBean
+    private CookieUtil cookieUtil;
+
     private final String API = "/api/email";
     private final String EMAIL = "ehd0309@naver.com";
+
     @Test
     @DisplayName("이메일 인증 코드 전송 응답 테스트")
     void sendEmailVerificationCodeTest() throws Exception {
@@ -50,6 +59,23 @@ class EmailControllerTest {
                 .andExpect(status().isOk())
                 .andDo(print());
         verify(emailService).sendVerificationCode(EMAIL);
+    }
+
+    @Test
+    @DisplayName("이메일 인증 코드 검증 응답 테스트")
+    void verifyEmailCodeTest() throws Exception {
+        EmailConfirmRequest emailConfirmRequest = new EmailConfirmRequest(EMAIL, "CODE");
+        Cookie cookie = new Cookie("key", EMAIL);
+        given(cookieUtil.createCookie(anyString(), anyString(), anyInt()))
+                .willReturn(cookie);
+        MvcResult mvcResult = mockMvc.perform(post(API + "/confirm")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(emailConfirmRequest)))
+                .andExpect(status().isOk())
+                .andDo(print())
+                .andReturn();
+        Assertions.assertThat(mvcResult.getResponse().getHeader("Set-Cookie"))
+                .isNotBlank();
     }
 
 }

--- a/src/test/java/com/wnis/linkyway/redis/RedisProviderTest.java
+++ b/src/test/java/com/wnis/linkyway/redis/RedisProviderTest.java
@@ -91,6 +91,10 @@ class RedisProviderTest {
             return name;
         }
 
+        public int getAge() {
+            return age;
+        }
+
     }
 
     static class SampleWrongObj {

--- a/src/test/java/com/wnis/linkyway/util/cookie/CookieUtilTest.java
+++ b/src/test/java/com/wnis/linkyway/util/cookie/CookieUtilTest.java
@@ -1,0 +1,52 @@
+package com.wnis.linkyway.util.cookie;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.mock.web.MockHttpServletRequest;
+
+import javax.servlet.http.Cookie;
+
+import static org.assertj.core.api.Assertions.*;
+
+@SpringBootTest(classes = {CookieUtil.class})
+class CookieUtilTest {
+
+    MockHttpServletRequest request;
+
+    @Autowired
+    private CookieUtil cookieUtil;
+
+    @BeforeEach
+    void setup() {
+        request = new MockHttpServletRequest();
+        request.setCookies(new Cookie("name", "HI"));
+    }
+
+    @Test
+    @DisplayName("존재하는 쿠키에 대해 조회할 경우 해당 쿠키를 반환한다.")
+    void FindExistCookieByNameShouldReturnCookie() {
+        Cookie resultCookie = cookieUtil.getCookieByCookieName(request, "name");
+        assertThat(resultCookie).isNotNull();
+        assertThat(resultCookie.getValue()).isEqualTo("HI");
+    }
+
+    @Test
+    @DisplayName("존재하지 않는 쿠키에 대한 조회는 Null을 반환한다.")
+    void FindNotExistCookieByNameNoShouldReturnNull() {
+        Cookie resultCookie = cookieUtil.getCookieByCookieName(request, "gaeaegeag");
+        assertThat(resultCookie).isNull();
+    }
+
+    @Test
+    @DisplayName("쿠키 추가 테스트")
+    void shouldAddCookie() {
+        Cookie cookie = cookieUtil.createCookie("new", "newValue", 1);
+        assertThat(cookie).isNotNull();
+        assertThat(cookie.getName()).isEqualTo("new");
+        assertThat(cookie.getValue()).isEqualTo("newValue");
+    }
+
+}


### PR DESCRIPTION


### 구현한 것

<br>

**이메일 코드 검증 api 추가**

- `POST: /api/email/confirm` 
- `이메일` 과 `인증코드` 를 페이로드로 받아 `redis`와 대조하여 검증함.
- 검증되었을 경우에는 `redis`의 해당 인증 상태를 삭제하고 사용자에게 인증되었음을 쿠키로 전달

<br>

**쿠키 util 클래스 추가**
- 이메일 인증에 성공하면 redis에 있던 이메일 인증 관련 상태를 제거하고 인증된 상태임을 쿠키로 클라이언트에게 전달해줌
- 이메일 인증이 필요한 요청의 api 라면 요청으로부터 쿠키를  가져와 검증함

<br>

**이메일 인증이 필요한 api를 위한 aop  추가**

> 다음과 같은 어노테이션을 만들고 aop에서 해당 어노테이션이 붙은 메소드에 대해서 동작하도록 함

```java
@Target({ElementType.METHOD})
@Retention(RetentionPolicy.RUNTIME)
public @interface WithEmailVerification {
}
```

<br>

```java
@Pointcut("@annotation(com.wnis.linkyway.aop.WithEmailVerification)")
public void withEmailVerification() {
}
```

<br>

> 다음과 같이 필요한 컨트롤러 api 메소드에 붙여주면 됨
 
```java
    @PostMapping
    @WithEmailVerification
    public ResponseEntity<Response> join(
            @Validated(ValidationSequence.class) @RequestBody JoinRequest joinRequest) {
        MemberResponse response = memberService.join(joinRequest);
        return ResponseEntity.ok(Response.of(HttpStatus.OK, response, "회원가입 성공"));
    }
```

<br>

> 이메일 인증이 필요한 api 에 대해서 mvc test 할 경우 다음처럼 쿠키만 넣어주면 됨

```java
mockMvc.perform(post("/api/members")
                    .cookie(cookie)
```

<br>

**특이사항**

- 라이브러리 때문의 불가피한 `checked exception` 에 대한 테스트는 우선 대부분 제외함
- `AOP` 의 경우 직접적으로는 단위 테스트하지 않음 (할 수 있나 궁금함)
- `회원가입 api` 의 경우만 이메일 인증 처리를  적용시키고 테스트도 통과시켜놓았습니다
- develop 분기 시점에서 테스트 11개 실패 => 구현 후에도 11개 실패

<br>

**요청사항**

- API 리소스명 더 좋은거 있으면 바꿔주세요
- redis 처리 등등 yml 은 일부러 전부 적용 안해두었습니다. 프로파일 분리하시고 직접 넣어주세요.
- 로컬,테스트 환경도 분리한다면 redis port 가 둘이 다르게 하면 편할 것 같습니다.

<br>

