### PR TITLE
Feat/#138/api 문서 설명 추가

### DIFF
--- a/src/main/java/com/wnis/linkyway/controller/CardController.java
+++ b/src/main/java/com/wnis/linkyway/controller/CardController.java
@@ -3,6 +3,7 @@ package com.wnis.linkyway.controller;
 import java.net.URI;
 import java.util.List;
 
+import io.swagger.annotations.ApiOperation;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.validation.annotation.Validated;
@@ -28,6 +29,7 @@ public class CardController {
     private final CardService cardService;
 
     @PostMapping
+    @ApiOperation(value = "카드 생성", notes = "카드 요청 정보를 입력 받아 카드 하나를 생성한다")
     @Authenticated
     public ResponseEntity<Response> addCard(@CurrentMember Long memberId,
             @Validated(ValidationSequence.class) @RequestBody CardRequest cardRequest) {
@@ -43,6 +45,7 @@ public class CardController {
     }
 
     @GetMapping("/{cardId}")
+    @ApiOperation(value = "ID를 통해 카드 조회", notes = "Card ID를 활용해 하나의 카드를 조회한다")
     @Authenticated
     public ResponseEntity<Response> findCardByCardId(@PathVariable Long cardId) {
 
@@ -57,6 +60,7 @@ public class CardController {
     }
 
     @PutMapping("/{cardId}")
+    @ApiOperation(value = "카드 수정", notes = "카드 수정 정보를 이용해 카드를 수정한다")
     @Authenticated
     public ResponseEntity<Response> updateCard(@CurrentMember Long memberId,
             @PathVariable Long cardId,
@@ -72,6 +76,7 @@ public class CardController {
     }
 
     @DeleteMapping("/{cardId}")
+    @ApiOperation(value = "카드 완전 삭제", notes = "DB에서 카드를 완전히 삭제한다")
     @Authenticated
     public ResponseEntity<Response> deleteCard(@PathVariable Long cardId) {
 
@@ -85,6 +90,7 @@ public class CardController {
     }
 
     @GetMapping("/personal/keyword")
+    @ApiOperation(value = "키워드를 통한 카드 조회", notes = "키워드를 활용해 여러 카드를 조회한다")
     @Authenticated
     public ResponseEntity<Response> searchCardByKeywordPersonalPage(@RequestParam(value = "keyword") String keyword,
             @CurrentMember Long memberId) {
@@ -94,6 +100,7 @@ public class CardController {
     }
 
     @GetMapping("/tag/{tagId}")
+    @ApiOperation(value = "태그아이디를 통해 카드 조회", notes = "TAG ID를 가지고 있는 여러 카드를 조회")
     @Authenticated
     public ResponseEntity<Response> findCardsByTagId(@CurrentMember Long memberId, @PathVariable Long tagId) {
 
@@ -107,6 +114,7 @@ public class CardController {
     }
 
     @GetMapping("/package/{tagId}")
+    @ApiOperation(value = "태그아이디를 통해 패키지 조회", notes = "태그 아이디를 활용해 여러 태그 아이디 조회")
     @Authenticated
     public ResponseEntity<Response> findShareableCardsByTagId(@PathVariable Long tagId) {
 
@@ -120,6 +128,7 @@ public class CardController {
     }
 
     @GetMapping("/folder/{folderId}")
+    @ApiOperation(value = "폴더 아이디를 활용한 카드 조회", notes = "FOLDER ID에 속해있는 카드들 모두 조회")
     @Authenticated
     public ResponseEntity<Response> findCardsByFolderId(@CurrentMember Long memberId,
             @PathVariable Long folderId,
@@ -135,6 +144,7 @@ public class CardController {
     }
 
     @GetMapping("/all")
+    @ApiOperation(value = "회원 카드 조회", notes = "회원이 가지고 있는 모든 카드 조회")
     @Authenticated
     public ResponseEntity<Response> findCardsByMemberId(@CurrentMember Long memberId) {
 
@@ -148,6 +158,7 @@ public class CardController {
     }
 
     @PostMapping("/package/copy")
+    @ApiOperation(value = "패키지 카드 복사", notes = "패키지에 있는 카드 모두 복사")
     @Authenticated
     public ResponseEntity<Response> copyCardsInPackage(
             @Validated(ValidationSequence.class) @RequestBody CopyPackageCardsRequest copyPackageCardsRequest) {

--- a/src/main/java/com/wnis/linkyway/controller/MemberController.java
+++ b/src/main/java/com/wnis/linkyway/controller/MemberController.java
@@ -6,6 +6,7 @@ import com.wnis.linkyway.security.annotation.Authenticated;
 import com.wnis.linkyway.security.annotation.CurrentMember;
 import com.wnis.linkyway.service.MemberService;
 import com.wnis.linkyway.validation.ValidationSequence;
+import io.swagger.annotations.ApiOperation;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -20,6 +21,7 @@ public class MemberController {
     private final MemberService memberService;
     
     @PostMapping
+    @ApiOperation(value = "회원가입", notes = "회원정보를 입력해 회원가입(같은 IP로 N회 이상 요청 불가능하다)")
     public ResponseEntity<Response> join(
             @Validated(ValidationSequence.class) @RequestBody JoinRequest joinRequest) {
         MemberResponse response = memberService.join(joinRequest);
@@ -27,38 +29,44 @@ public class MemberController {
     }
     
     @PostMapping("/login")
+    @ApiOperation(value = "로그인", notes = "로그인 이후 JWT 토큰 리턴(같은 IP로 N회 이상 요청 불가능하다)")
     public ResponseEntity<Void> login(@RequestBody LoginRequest loginRequest) {
         return ResponseEntity.ok().build();
     }
     
     
     @GetMapping("/email")
+    @ApiOperation(value = "이메일 조회", notes = "해당 이메일이 실제 등록되어 있는지 조회한다")
     public ResponseEntity<Response> searchEmail(@RequestParam String email) {
         MemberResponse response = memberService.searchEmail(email);
         return ResponseEntity.ok(Response.of(HttpStatus.OK, response, "이메일 조회 성공"));
     }
 
     @GetMapping("/nickname")
+    @ApiOperation(value = "닉네입 조회", notes = "닉네임의 중복 여부를 확인하기 위한 조회한다")
     public ResponseEntity<Response<DuplicationResponse>> searchNicknameDuplicationInfo(@RequestParam String nickname) {
         DuplicationResponse response = memberService.isValidNickname(nickname);
         return  ResponseEntity.ok(Response.of(HttpStatus.OK, response, "닉네임 사용가능 여부 조회 성공"));
     }
     
     @GetMapping("/page/me")
+    @ApiOperation(value = "회원 정보 조회", notes = "가지고 있는 토큰 정보를 활용해 회원 정보 조회한다")
     @Authenticated
     public ResponseEntity<Response> searchMyPage(@CurrentMember Long memberId) {
         MemberResponse response = memberService.searchMyPage(memberId);
         return ResponseEntity.ok(Response.of(HttpStatus.OK, response, "마이 페이지 조회"));
     }
     
-    @PutMapping("/page/me")
-    @Authenticated
-    public ResponseEntity<Response> updateMyPage(@CurrentMember Long memberId) {
-        MemberResponse response = memberService.searchMyPage(memberId);
-        return ResponseEntity.ok(Response.of(HttpStatus.OK, response, "마이 페이지 조회"));
-    }
+//    @PutMapping("/page/me")
+//    @ApiOperation(value = "회원 정보 수정", notes = "가지고 있는 토큰과 요청 정보를 활용해 회원 정보와 수정한다")
+//    @Authenticated
+//    public ResponseEntity<Response> updateMyPage(@CurrentMember Long memberId) {
+//        MemberResponse response = memberService.searchMyPage(memberId);
+//        return ResponseEntity.ok(Response.of(HttpStatus.OK, response, "마이 페이지 조회"));
+//    }
     
     @PutMapping("/password")
+    @ApiOperation(value = "회원 비밀번호 수정", notes = "회원 비밀번호를 수정한다")
     @Authenticated
     public ResponseEntity<Response> updatePassword(
             @Validated(ValidationSequence.class) @RequestBody PasswordRequest passwordRequest,
@@ -68,6 +76,7 @@ public class MemberController {
     }
     
     @DeleteMapping
+    @ApiOperation(value = "회원 탈퇴", notes = "회원을 삭제한다")
     @Authenticated
     public ResponseEntity<Response> deleteMember(@CurrentMember Long memberId) {
         MemberResponse response = memberService.deleteMember(memberId);


### PR DESCRIPTION
# 특이 사항

- swagger api 문서에 api 설명이 나오도록 함

![image](https://user-images.githubusercontent.com/39326175/174737189-cc6757bd-cbdf-4d0b-9df4-f702c324539a.png)

- 멤버 회원정보 수정이 service 구현이 안되어 있는데 컨트롤러는 있어서 주석 처리 해놓음.