### PR TITLE
소셜 카드의 Response에서 FolderId 제거

### DIFF
--- a/src/main/java/com/wnis/linkyway/controller/CardController.java
+++ b/src/main/java/com/wnis/linkyway/controller/CardController.java
@@ -13,6 +13,7 @@ import com.wnis.linkyway.dto.card.AddCardResponse;
 import com.wnis.linkyway.dto.card.CardRequest;
 import com.wnis.linkyway.dto.card.CardResponse;
 import com.wnis.linkyway.dto.card.CopyPackageCardsRequest;
+import com.wnis.linkyway.dto.card.SocialCardResponse;
 import com.wnis.linkyway.security.annotation.Authenticated;
 import com.wnis.linkyway.security.annotation.CurrentMember;
 import com.wnis.linkyway.service.card.CardService;
@@ -110,7 +111,7 @@ public class CardController {
     @Authenticated
     public ResponseEntity<Response> findIsPublicCardsByTagId(@PathVariable Long tagId) {
 
-        List<CardResponse> cardResponses = cardService.findIsPublicCardsByTagId(tagId);
+        List<SocialCardResponse> cardResponses = cardService.findIsPublicCardsByTagId(tagId);
         return ResponseEntity.ok()
                              .body(Response.builder()
                                            .code(HttpStatus.OK.value())

--- a/src/main/java/com/wnis/linkyway/controller/CardController.java
+++ b/src/main/java/com/wnis/linkyway/controller/CardController.java
@@ -108,9 +108,9 @@ public class CardController {
 
     @GetMapping("/package/{tagId}")
     @Authenticated
-    public ResponseEntity<Response> findShareableCardsByTagId(@PathVariable Long tagId) {
+    public ResponseEntity<Response> findIsPublicCardsByTagId(@PathVariable Long tagId) {
 
-        List<CardResponse> cardResponses = cardService.findShareableCardsByTagId(tagId);
+        List<CardResponse> cardResponses = cardService.findIsPublicCardsByTagId(tagId);
         return ResponseEntity.ok()
                              .body(Response.builder()
                                            .code(HttpStatus.OK.value())

--- a/src/main/java/com/wnis/linkyway/dto/card/SocialCardResponse.java
+++ b/src/main/java/com/wnis/linkyway/dto/card/SocialCardResponse.java
@@ -1,0 +1,37 @@
+package com.wnis.linkyway.dto.card;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.wnis.linkyway.dto.tag.TagResponse;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@Getter
+@NoArgsConstructor
+@JsonInclude(JsonInclude.Include.NON_EMPTY)
+public class SocialCardResponse {
+
+    private Long cardId;
+
+    private String link;
+
+    private String title;
+
+    private String content;
+
+    private Boolean isPublic;
+
+    private List<TagResponse> tags = new ArrayList<>();
+
+    public SocialCardResponse(CardResponse cardResponse) {
+        this.cardId = cardResponse.getCardId();
+        this.link = cardResponse.getLink();
+        this.title = cardResponse.getTitle();
+        this.content = cardResponse.getContent();
+        this.isPublic = cardResponse.getIsPublic();
+        this.tags = cardResponse.getTags();
+    }
+
+}

--- a/src/main/java/com/wnis/linkyway/dto/card/SocialCardResponse.java
+++ b/src/main/java/com/wnis/linkyway/dto/card/SocialCardResponse.java
@@ -21,8 +21,6 @@ public class SocialCardResponse {
 
     private String content;
 
-    private Boolean isPublic;
-
     private List<TagResponse> tags = new ArrayList<>();
 
     public SocialCardResponse(CardResponse cardResponse) {
@@ -30,7 +28,6 @@ public class SocialCardResponse {
         this.link = cardResponse.getLink();
         this.title = cardResponse.getTitle();
         this.content = cardResponse.getContent();
-        this.isPublic = cardResponse.getIsPublic();
         this.tags = cardResponse.getTags();
     }
 

--- a/src/main/java/com/wnis/linkyway/entity/Card.java
+++ b/src/main/java/com/wnis/linkyway/entity/Card.java
@@ -40,9 +40,9 @@ public class Card extends BaseEntity {
     @Column(name = "is_public", nullable = false)
     private Boolean isPublic;
 
-    @Column(name = "is_deleted", nullable = false)
     @ColumnDefault("false")
-    private Boolean isDeleted;
+    @Column(name = "is_deleted", nullable = false)
+    private Boolean isDeleted = false;
 
     //// ********************연관 관게 ***************************/////
     @ManyToOne(fetch = FetchType.LAZY)

--- a/src/main/java/com/wnis/linkyway/repository/CardRepository.java
+++ b/src/main/java/com/wnis/linkyway/repository/CardRepository.java
@@ -16,10 +16,10 @@ public interface CardRepository extends JpaRepository<Card, Long> {
 
     @Query("select ct.card from CardTag ct join ct.card join ct.tag where ct.tag.id = :tagId")
     public List<Card> findCardsByTagId(@Param(value = "tagId") Long tagId);
-
+    
     @Query("select distinct ct.card from CardTag ct join ct.card c join ct.tag t "
             + "where t.id = :tagId and c.isPublic = true")
-    public List<Card> findShareableCardsByTagId(@Param(value = "tagId") Long tagId);
+    public List<Card> findIsPublicCardsByTagId(@Param(value = "tagId") Long tagId);
 
     @Query("select c from Card c join c.folder f where f.id = :folderId")
     public List<Card> findCardsByFolderId(@Param(value = "folderId") Long folderId);

--- a/src/main/java/com/wnis/linkyway/service/card/CardService.java
+++ b/src/main/java/com/wnis/linkyway/service/card/CardService.java
@@ -4,6 +4,7 @@ import com.wnis.linkyway.dto.card.AddCardResponse;
 import com.wnis.linkyway.dto.card.CardRequest;
 import com.wnis.linkyway.dto.card.CardResponse;
 import com.wnis.linkyway.dto.card.CopyPackageCardsRequest;
+import com.wnis.linkyway.dto.card.SocialCardResponse;
 import com.wnis.linkyway.entity.Card;
 
 import java.util.List;
@@ -22,7 +23,7 @@ public interface CardService {
 
     public List<CardResponse> findCardsByTagId(Long memberId, Long tagId);
 
-    public List<CardResponse> findIsPublicCardsByTagId(Long tagId);
+    public List<SocialCardResponse> findIsPublicCardsByTagId(Long tagId);
 
     public List<CardResponse> findCardsByFolderId(Long memberId, Long folderId, boolean findDeep);
 

--- a/src/main/java/com/wnis/linkyway/service/card/CardService.java
+++ b/src/main/java/com/wnis/linkyway/service/card/CardService.java
@@ -22,7 +22,7 @@ public interface CardService {
 
     public List<CardResponse> findCardsByTagId(Long memberId, Long tagId);
 
-    public List<CardResponse> findShareableCardsByTagId(Long tagId);
+    public List<CardResponse> findIsPublicCardsByTagId(Long tagId);
 
     public List<CardResponse> findCardsByFolderId(Long memberId, Long folderId, boolean findDeep);
 

--- a/src/main/java/com/wnis/linkyway/service/card/CardServiceImpl.java
+++ b/src/main/java/com/wnis/linkyway/service/card/CardServiceImpl.java
@@ -176,15 +176,15 @@ public class CardServiceImpl implements CardService {
 
     @Override
     @Transactional
-    public List<CardResponse> findShareableCardsByTagId(Long tagId) {
+    public List<CardResponse> findIsPublicCardsByTagId(Long tagId) {
         Tag tag = tagRepository.findById(tagId)
                                .orElseThrow(() -> new ResourceConflictException("존재하지 않는 태그입니다. 태그를 확인해주세요."));
         if (!tag.getIsPublic()) {
             throw new NotAccessableException("소셜 공유가 허용되지 않은 태그입니다.");
         }
 
-        List<Card> cardList = cardRepository.findShareableCardsByTagId(tagId);
         return toResponseList(cardList);
+        List<Card> cardList = cardRepository.findIsPublicCardsByTagId(tagId);
     }
 
     @Override

--- a/src/main/java/com/wnis/linkyway/service/card/CardServiceImpl.java
+++ b/src/main/java/com/wnis/linkyway/service/card/CardServiceImpl.java
@@ -76,7 +76,8 @@ public class CardServiceImpl implements CardService {
                            .link(card.getLink())
                            .title(card.getTitle())
                            .content(card.getContent())
-                           .folderId(card.getFolder().getId())
+                           .folderId(card.getFolder()
+                                         .getId())
                            .isPublic(card.getIsPublic())
                            .tags(tagResponseList)
                            .build();
@@ -217,21 +218,22 @@ public class CardServiceImpl implements CardService {
         List<CardResponse> cardResponseList = new ArrayList<CardResponse>();
         for (Card card : cardList) {
             List<Tag> tagList = card.getCardTags()
-                                .stream()
-                                .map(CardTag::getTag)
-                                .collect(Collectors.toList());
-            
+                                    .stream()
+                                    .map(CardTag::getTag)
+                                    .collect(Collectors.toList());
+
             List<TagResponse> tagResponseList = tagList.stream()
-                                         .map((tag) -> new TagResponse(tag))
-                                         .collect(Collectors.toList());
-            
+                                                       .map((tag) -> new TagResponse(tag))
+                                                       .collect(Collectors.toList());
+
             cardResponseList.add(CardResponse.builder()
                                              .cardId(card.getId())
                                              .title(card.getTitle())
                                              .content(card.getContent())
                                              .link(card.getLink())
                                              .tags(tagResponseList)
-                                             .folderId(card.getFolder().getId())
+                                             .folderId(card.getFolder()
+                                                           .getId())
                                              .isPublic(card.getIsPublic())
                                              .build());
         }

--- a/src/main/java/com/wnis/linkyway/service/card/CardServiceImpl.java
+++ b/src/main/java/com/wnis/linkyway/service/card/CardServiceImpl.java
@@ -14,6 +14,7 @@ import com.wnis.linkyway.dto.card.CardRequest;
 import com.wnis.linkyway.dto.card.CardResponse;
 import com.wnis.linkyway.dto.card.CopyCardsRequest;
 import com.wnis.linkyway.dto.card.CopyPackageCardsRequest;
+import com.wnis.linkyway.dto.card.SocialCardResponse;
 import com.wnis.linkyway.dto.tag.TagResponse;
 import com.wnis.linkyway.entity.Card;
 import com.wnis.linkyway.entity.CardTag;
@@ -176,15 +177,17 @@ public class CardServiceImpl implements CardService {
 
     @Override
     @Transactional
-    public List<CardResponse> findIsPublicCardsByTagId(Long tagId) {
+    public List<SocialCardResponse> findIsPublicCardsByTagId(Long tagId) {
         Tag tag = tagRepository.findById(tagId)
                                .orElseThrow(() -> new ResourceConflictException("존재하지 않는 태그입니다. 태그를 확인해주세요."));
         if (!tag.getIsPublic()) {
             throw new NotAccessableException("소셜 공유가 허용되지 않은 태그입니다.");
         }
 
-        return toResponseList(cardList);
         List<Card> cardList = cardRepository.findIsPublicCardsByTagId(tagId);
+        return toResponseList(cardList).stream()
+                                       .map((cardResponse) -> new SocialCardResponse(cardResponse))
+                                       .collect(Collectors.toList());
     }
 
     @Override


### PR DESCRIPTION
소셜에서 보여지는 카드에 FolderId를 제거하기 위해 일반 카드 Response와 소셜 카드 Response를 분리함.