### PR TITLE
Feat/#141/회원 정보 수정(마이페이지)

### DIFF
--- a/src/main/java/com/wnis/linkyway/controller/MemberController.java
+++ b/src/main/java/com/wnis/linkyway/controller/MemberController.java
@@ -50,14 +50,16 @@ public class MemberController {
     @Authenticated
     public ResponseEntity<Response> searchMyPage(@CurrentMember Long memberId) {
         MemberResponse response = memberService.searchMyPage(memberId);
-        return ResponseEntity.ok(Response.of(HttpStatus.OK, response, "마이 페이지 조회"));
+        return ResponseEntity.ok(Response.of(HttpStatus.OK, response, "마이 페이지 조회 성공"));
     }
     
     @PutMapping("/page/me")
     @Authenticated
-    public ResponseEntity<Response> updateMyPage(@CurrentMember Long memberId) {
-        MemberResponse response = memberService.searchMyPage(memberId);
-        return ResponseEntity.ok(Response.of(HttpStatus.OK, response, "마이 페이지 조회"));
+    public ResponseEntity<Response> updateMyPage(
+            @Validated(ValidationSequence.class) @RequestBody UpdateMemberRequest updateMemberRequest,
+            @CurrentMember Long memberId) {
+        MemberResponse response = memberService.updateMyPage(updateMemberRequest, memberId);
+        return ResponseEntity.ok(Response.of(HttpStatus.OK, response, "마이 페이지 수정 성공"));
     }
     
     @PutMapping("/password")

--- a/src/main/java/com/wnis/linkyway/dto/member/JoinRequest.java
+++ b/src/main/java/com/wnis/linkyway/dto/member/JoinRequest.java
@@ -26,7 +26,7 @@ public class JoinRequest {
     private String password;
 
     @NotBlank(message = "닉네임을 입력해주세요", groups = NotBlankGroup.class)
-    @Pattern(regexp = "^[ㄱ-ㅎ가-힣a-zA-Z\\d_]{2,10}$",
+    @Pattern(regexp = "^[가-힣a-zA-Z\\d_]{2,10}$",
              message = "문자/숫자로만 2~10 글자 사이로 입력해주세요",
              groups = PatternCheckGroup.class)
     private String nickname;

--- a/src/main/java/com/wnis/linkyway/dto/member/UpdateMemberRequest.java
+++ b/src/main/java/com/wnis/linkyway/dto/member/UpdateMemberRequest.java
@@ -14,7 +14,7 @@ import javax.validation.constraints.Pattern;
 public class UpdateMemberRequest {
     
     @NotBlank(message = "닉네임을 입력해주세요", groups = ValidationGroup.NotBlankGroup.class)
-    @Pattern(regexp = "^[ㄱ-ㅎ가-힣a-zA-Z\\d_]{2,10}$",
+    @Pattern(regexp = "^[가-힣a-zA-Z\\d_]{2,10}$",
             message = "문자/숫자로만 2~10 글자 사이로 입력해주세요",
             groups = ValidationGroup.PatternCheckGroup.class)
     private String nickname;

--- a/src/main/java/com/wnis/linkyway/dto/member/UpdateMemberRequest.java
+++ b/src/main/java/com/wnis/linkyway/dto/member/UpdateMemberRequest.java
@@ -1,0 +1,21 @@
+package com.wnis.linkyway.dto.member;
+
+import com.wnis.linkyway.validation.ValidationGroup;
+import lombok.*;
+
+import javax.validation.constraints.NotBlank;
+import javax.validation.constraints.Pattern;
+
+
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+public class UpdateMemberRequest {
+    
+    @NotBlank(message = "닉네임을 입력해주세요", groups = ValidationGroup.NotBlankGroup.class)
+    @Pattern(regexp = "^[ㄱ-ㅎ가-힣a-zA-Z\\d_]{2,10}$",
+            message = "문자/숫자로만 2~10 글자 사이로 입력해주세요",
+            groups = ValidationGroup.PatternCheckGroup.class)
+    private String nickname;
+}

--- a/src/main/java/com/wnis/linkyway/service/MemberService.java
+++ b/src/main/java/com/wnis/linkyway/service/MemberService.java
@@ -69,9 +69,7 @@ public class MemberService {
     
     @Transactional
     public MemberResponse updateMyPage(UpdateMemberRequest updateMemberRequest, Long memberId) {
-        if (memberRepository.existsByNickname(updateMemberRequest.getNickname())) {
-            throw new NotAddDuplicateEntityException("중복된 닉네임을 입력 할 수 없습니다");
-        }
+        validNicknameDuplication(updateMemberRequest.getNickname())
         
         Member member = memberRepository.findById(memberId)
                 .orElseThrow(() -> new NotFoundEntityException("회원을 찾을 수 없습니다"));

--- a/src/main/java/com/wnis/linkyway/service/MemberService.java
+++ b/src/main/java/com/wnis/linkyway/service/MemberService.java
@@ -66,6 +66,23 @@ public class MemberService {
 
         return MemberResponse.from(member);
     }
+    
+    @Transactional
+    public MemberResponse updateMyPage(UpdateMemberRequest updateMemberRequest, Long memberId) {
+        if (memberRepository.existsByNickname(updateMemberRequest.getNickname())) {
+            throw new NotAddDuplicateEntityException("중복된 닉네임을 입력 할 수 없습니다");
+        }
+        
+        Member member = memberRepository.findById(memberId)
+                .orElseThrow(() -> new NotFoundEntityException("회원을 찾을 수 없습니다"));
+        
+        member.updateNickname(updateMemberRequest.getNickname());
+        
+        return MemberResponse.builder()
+                .memberId(memberId)
+                .nickname(member.getNickname())
+                .build();
+    }
 
     @Transactional
     public MemberResponse updatePassword(PasswordRequest passwordRequest, Long memberId) {

--- a/src/test/java/com/wnis/linkyway/controller/member/MemberControllerIntegrationTest.java
+++ b/src/test/java/com/wnis/linkyway/controller/member/MemberControllerIntegrationTest.java
@@ -1,9 +1,11 @@
-package com.wnis.linkyway.controller;
+package com.wnis.linkyway.controller.member;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.wnis.linkyway.controller.tag.TagControllerIntegrationTest;
 import com.wnis.linkyway.dto.member.JoinRequest;
 import com.wnis.linkyway.dto.member.PasswordRequest;
+import com.wnis.linkyway.dto.member.UpdateMemberRequest;
 import com.wnis.linkyway.security.testutils.WithMockMember;
 import com.wnis.linkyway.util.cookie.CookieConstants;
 import org.junit.jupiter.api.BeforeEach;
@@ -15,6 +17,7 @@ import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.MediaType;
 import org.springframework.test.context.jdbc.Sql;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.MvcResult;
@@ -182,6 +185,24 @@ class MemberControllerIntegrationTest {
 
     }
 
+    @Nested
+    @DisplayName("회원 수정 테스트")
+    @WithMockMember(id = 1L, email = "marrin1101@hanmail.com")
+    class UpdateMemberTest {
+        
+        @Test
+        @DisplayName("응답 테스트")
+        void responseTest() throws Exception {
+            UpdateMemberRequest updateMemberRequest = UpdateMemberRequest.builder()
+                                                                         .nickname("hello").build();
+            
+            mockMvc.perform(put("/api/members/page/me")
+                                    .contentType(MediaType.APPLICATION_JSON)
+                                    .content(objectMapper.writeValueAsString(updateMemberRequest)))
+                   .andExpect(status().is(200));
+        }
+    }
+    
     @Nested
     @DisplayName("회원 삭제 테스트")
     @WithMockMember(id = 1L, email = "marrin1101@hanmail.com")

--- a/src/test/java/com/wnis/linkyway/controller/member/MemberControllerTest.java
+++ b/src/test/java/com/wnis/linkyway/controller/member/MemberControllerTest.java
@@ -1,0 +1,99 @@
+package com.wnis.linkyway.controller.member;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.wnis.linkyway.controller.MemberController;
+import com.wnis.linkyway.dto.member.UpdateMemberRequest;
+import com.wnis.linkyway.exception.common.NotAddDuplicateEntityException;
+import com.wnis.linkyway.exception.common.NotFoundEntityException;
+import com.wnis.linkyway.service.MemberService;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.context.annotation.ComponentScan;
+import org.springframework.context.annotation.FilterType;
+import org.springframework.http.MediaType;
+import org.springframework.security.config.annotation.web.configuration.WebSecurityConfigurerAdapter;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+import org.springframework.web.context.WebApplicationContext;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doThrow;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@WebMvcTest(controllers = MemberController.class,
+        excludeFilters = { @ComponentScan.Filter(type = FilterType.ASSIGNABLE_TYPE,
+                classes = WebSecurityConfigurerAdapter.class) })
+public class MemberControllerTest {
+    
+    @Autowired
+    MockMvc mockMvc;
+    
+    @MockBean
+    MemberService memberService;
+    
+    @Autowired
+    WebApplicationContext ctx;
+    
+    @Autowired
+    ObjectMapper objectMapper;
+    
+    @BeforeEach
+    void setUp() {
+        mockMvc = MockMvcBuilders.webAppContextSetup(ctx)
+                                 .alwaysDo(print())
+                                 .build();
+    }
+    
+    
+    @Nested
+    @DisplayName("회원 수정")
+    class updateMemberTest {
+        
+        @Test
+        @DisplayName("입력 Validation 테스트")
+        void shouldReturnStatus400_WhenInvalidInputTest() throws Exception {
+            UpdateMemberRequest updateMemberRequest = UpdateMemberRequest.builder()
+                    .nickname("adksjflkajsdljaksdflksjflasdkfjsdjfjsalkjfasdfas").build();
+            
+            mockMvc.perform(put("/api/members/page/me")
+                                    .contentType(MediaType.APPLICATION_JSON)
+                                    .content(objectMapper.writeValueAsString(updateMemberRequest)))
+                   .andExpect(status().is(400));
+        }
+    
+        @Test
+        @DisplayName("닉네임 중복시 테스트")
+        void shouldReturnStatus409_WhenThrowDuplicateNicknameTest() throws Exception {
+            UpdateMemberRequest updateMemberRequest = UpdateMemberRequest.builder()
+                                                                         .nickname("hello").build();
+    
+            doThrow(new NotAddDuplicateEntityException("h")).when(memberService).updateMyPage(any(), any());
+            
+            mockMvc.perform(put("/api/members/page/me")
+                                    .contentType(MediaType.APPLICATION_JSON)
+                                    .content(objectMapper.writeValueAsString(updateMemberRequest)))
+                   .andExpect(status().is(409));
+        }
+    
+        @Test
+        @DisplayName("회원 정보가 없을 시 테스트")
+        void shouldReturnStatus404_WhenThrowNotFoundIDTest() throws Exception {
+            UpdateMemberRequest updateMemberRequest = UpdateMemberRequest.builder()
+                                                                         .nickname("hello").build();
+        
+            doThrow(new NotFoundEntityException(" ")).when(memberService).updateMyPage(any(), any());
+        
+            mockMvc.perform(put("/api/members/page/me")
+                                    .contentType(MediaType.APPLICATION_JSON)
+                                    .content(objectMapper.writeValueAsString(updateMemberRequest)))
+                   .andExpect(status().is(404));
+        }
+    }
+}

--- a/src/test/java/com/wnis/linkyway/controller/member/MemberControllerTest.java
+++ b/src/test/java/com/wnis/linkyway/controller/member/MemberControllerTest.java
@@ -79,7 +79,7 @@ public class MemberControllerTest {
             mockMvc.perform(put("/api/members/page/me")
                                     .contentType(MediaType.APPLICATION_JSON)
                                     .content(objectMapper.writeValueAsString(updateMemberRequest)))
-                   .andExpect(status().is(409));
+                   .andExpect(status().isConflict());
         }
     
         @Test

--- a/src/test/java/com/wnis/linkyway/service/MemberServiceTest.java
+++ b/src/test/java/com/wnis/linkyway/service/MemberServiceTest.java
@@ -5,9 +5,8 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.wnis.linkyway.dto.member.JoinRequest;
 import com.wnis.linkyway.dto.member.MemberResponse;
 import com.wnis.linkyway.dto.member.PasswordRequest;
-import com.wnis.linkyway.exception.common.InvalidValueException;
-import com.wnis.linkyway.exception.common.ResourceConflictException;
-import com.wnis.linkyway.exception.common.ResourceNotFoundException;
+import com.wnis.linkyway.dto.member.UpdateMemberRequest;
+import com.wnis.linkyway.exception.common.*;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
@@ -126,6 +125,53 @@ class MemberServiceTest {
             }).isInstanceOf(ResourceNotFoundException.class)
               .hasMessage("회원을 찾을 수 없습니다");
 
+        }
+    }
+    
+    @Nested
+    @DisplayName("마이페이지 수정")
+    class UpdateMemberTest {
+        
+        @Test
+        @DisplayName("응답 테스트")
+        void shouldReturnIdAndUpdatedNicknameWhenResponseTest() {
+            // given
+            UpdateMemberRequest updateMemberRequest = UpdateMemberRequest.builder()
+                    .nickname("쿠로사키 2치고").build();
+            // when
+            MemberResponse memberResponse = memberService.updateMyPage(updateMemberRequest, 1L);
+            
+            // then
+            assertThat(memberResponse.getMemberId()).isNotNull();
+            assertThat(memberResponse.getNickname()).isNotNull();
+        }
+        
+        @Test
+        @DisplayName("닉네임 중복 여부")
+        void shouldThrowDuplicateException_WhenInputDuplicateNicknameTest() {
+            // given
+            UpdateMemberRequest updateMemberRequest = UpdateMemberRequest.builder()
+                    .nickname("Zeratu6")
+                    .build();
+            
+            
+            assertThatThrownBy(()-> {
+                // when
+                memberService.updateMyPage(updateMemberRequest, 1L);
+            }).isInstanceOf(NotAddDuplicateEntityException.class); // then
+        }
+        
+        @Test
+        @DisplayName("회원입력이 옳바르지 않은 경우")
+        void shouldThrowNotFoundException_WhenInputInvalidMemberIdTest() {
+            // given
+            UpdateMemberRequest updateMemberRequest = UpdateMemberRequest.builder()
+                         .nickname("손흥민").build();
+    
+            assertThatThrownBy(()-> {
+                // when
+                memberService.updateMyPage(updateMemberRequest, 100L);
+            }).isInstanceOf(NotFoundEntityException.class); // then
         }
     }
 


### PR DESCRIPTION
# 특이사항
- 회원정보 수정(nickname만 수정)
- 요청 dto 구현
- 멤버 존재 여부와 닉네임 중복 여부로 예외 출력