### PR TITLE
로그인 N회 실패 시 일시적 요청 제한 기능 구현

### DIFF
--- a/src/main/java/com/wnis/linkyway/config/SecurityConfiguration.java
+++ b/src/main/java/com/wnis/linkyway/config/SecurityConfiguration.java
@@ -1,6 +1,7 @@
 package com.wnis.linkyway.config;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.wnis.linkyway.redis.RedisProvider;
 import com.wnis.linkyway.security.filter.JwtAuthenticationFilter;
 import com.wnis.linkyway.security.filter.JwtAuthorizationFilter;
 import com.wnis.linkyway.security.jwt.JwtProvider;
@@ -27,6 +28,7 @@ public class SecurityConfiguration extends WebSecurityConfigurerAdapter {
 
     private final ObjectMapper objectMapper;
     private final JwtProvider jwtProvider;
+    private final RedisProvider redisProvider;
 
     @Override
     protected void configure(HttpSecurity http) throws Exception {
@@ -71,7 +73,7 @@ public class SecurityConfiguration extends WebSecurityConfigurerAdapter {
 
     @Bean
     public JwtAuthenticationFilter jwtAuthenticationFilter() throws Exception {
-        JwtAuthenticationFilter jwtLoginFilter = new JwtAuthenticationFilter(objectMapper, jwtProvider);
+        JwtAuthenticationFilter jwtLoginFilter = new JwtAuthenticationFilter(objectMapper, jwtProvider, redisProvider);
         jwtLoginFilter.setAuthenticationManager(authenticationManagerBean());
         return jwtLoginFilter;
     }

--- a/src/main/java/com/wnis/linkyway/redis/RedisConstants.java
+++ b/src/main/java/com/wnis/linkyway/redis/RedisConstants.java
@@ -1,0 +1,16 @@
+package com.wnis.linkyway.redis;
+
+import lombok.AccessLevel;
+import lombok.NoArgsConstructor;
+
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+public class RedisConstants {
+
+    public static final String LOGIN_KEY_PREFIX = "LG-";
+    public static final int LOGIN_RESTRICT_COUNT = 5;
+    public static final long LOGIN_RESTRICT_TIMEOUT_MILLS = 1000 * 60 * 5L;
+
+    public static final long EMAIL_VALIDATION_EXPIRATION_TIME = 1000 * 60 * 15L;
+    public static final int EMAIL_VALIDATION_RETRY_COUNT = 5;
+
+}

--- a/src/main/java/com/wnis/linkyway/redis/values/EmailVerificationValue.java
+++ b/src/main/java/com/wnis/linkyway/redis/values/EmailVerificationValue.java
@@ -1,14 +1,15 @@
 package com.wnis.linkyway.redis.values;
 
 import com.wnis.linkyway.exception.common.EmailSendException;
+import com.wnis.linkyway.redis.RedisConstants;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
+
+import static com.wnis.linkyway.redis.RedisConstants.*;
 
 @Getter
 @AllArgsConstructor
 public class EmailVerificationValue {
-
-    private static final int RETRY_COUNT = 5;
 
     private int currentCount;
     private String code;
@@ -31,9 +32,9 @@ public class EmailVerificationValue {
     }
 
     private void checkRetryCount() {
-        if (currentCount >= RETRY_COUNT) {
+        if (currentCount >= EMAIL_VALIDATION_RETRY_COUNT) {
             throw new EmailSendException(
-                    "연속 " + RETRY_COUNT + "회 인증 요청으로 일시적으로 메일 전송이 제한되었습니다. 잠시후 다시 시도해주세요");
+                    "연속 " + EMAIL_VALIDATION_RETRY_COUNT + "회 인증 요청으로 일시적으로 메일 전송이 제한되었습니다. 잠시후 다시 시도해주세요");
         }
     }
 

--- a/src/main/java/com/wnis/linkyway/security/filter/JwtAuthenticationFilter.java
+++ b/src/main/java/com/wnis/linkyway/security/filter/JwtAuthenticationFilter.java
@@ -8,10 +8,12 @@ import com.wnis.linkyway.exception.common.BusinessException;
 import com.wnis.linkyway.exception.common.InvalidValueException;
 import com.wnis.linkyway.exception.error.ErrorCode;
 import com.wnis.linkyway.exception.error.ErrorResponse;
+import com.wnis.linkyway.redis.RedisProvider;
 import com.wnis.linkyway.security.jwt.JwtAuthenticationToken;
 import com.wnis.linkyway.security.jwt.JwtProvider;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
+import org.springframework.security.authentication.LockedException;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.AuthenticationException;
 import org.springframework.security.core.userdetails.UsernameNotFoundException;
@@ -26,25 +28,33 @@ import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
+import java.text.MessageFormat;
+import java.util.Optional;
+
+import static com.wnis.linkyway.redis.RedisConstants.*;
 
 @Slf4j
 public class JwtAuthenticationFilter extends AbstractAuthenticationProcessingFilter {
 
     private final ObjectMapper objectMapper;
     private final JwtProvider jwtProvider;
+    private final RedisProvider redisProvider;
 
     private static final String LOGIN_URL = "/api/members/login";
+    // NGINX 기준 헤더네임으로 서버 변경이 예상될 경우 프로파일 활용해 동적으로 처리
+    private static final String PROXY_HEADER = "X-Forwarded-For";
 
-    public JwtAuthenticationFilter(ObjectMapper objectMapper, JwtProvider jwtProvider) {
+    public JwtAuthenticationFilter(ObjectMapper objectMapper, JwtProvider jwtProvider, RedisProvider redisProvider) {
         super(new AntPathRequestMatcher(LOGIN_URL));
         this.objectMapper = objectMapper;
         this.jwtProvider = jwtProvider;
+        this.redisProvider = redisProvider;
     }
 
     @Override
     public Authentication attemptAuthentication(HttpServletRequest request, HttpServletResponse response)
             throws AuthenticationException, IOException, ServletException {
-
+        checkLoginAttemptRestricted(getIpFromRequest(request));
         LoginRequest loginRequest = getObjectFromInputStream(request.getInputStream(), LoginRequest.class);
         validLoginRequest(loginRequest);
 
@@ -69,7 +79,7 @@ public class JwtAuthenticationFilter extends AbstractAuthenticationProcessingFil
     protected void unsuccessfulAuthentication(HttpServletRequest request,
                                               HttpServletResponse response,
                                               AuthenticationException authException) throws IOException, ServletException {
-
+        increaseLoginAttemptRestrictedCount(getIpFromRequest(request));
         ErrorCode errorCode = isBusinessException(authException) ? ErrorCode.INVALID_INPUT_VALUE : ErrorCode.UNAUTHORIZED;
         int status = errorCode.getCode();
         String message = authException.getMessage();
@@ -104,6 +114,39 @@ public class JwtAuthenticationFilter extends AbstractAuthenticationProcessingFil
         response.setCharacterEncoding(StandardCharsets.UTF_8.displayName());
         response.getWriter()
                 .write(objectMapper.writeValueAsString(data));
+    }
+
+    private void increaseLoginAttemptRestrictedCount(String ip) {
+        int currentCount = getLoginAttemptCount(ip);
+        if (isPossibleRangeForIncreaseCount(currentCount)) {
+            redisProvider.setDataWithExpiration(
+                    LOGIN_KEY_PREFIX + ip, String.valueOf(currentCount + 1), LOGIN_RESTRICT_TIMEOUT_MILLS);
+        }
+    }
+
+    private boolean isPossibleRangeForIncreaseCount(int currentCount) {
+        return currentCount >= 0 && currentCount <= LOGIN_RESTRICT_COUNT;
+    }
+
+    private void checkLoginAttemptRestricted(String ip) {
+        if (getLoginAttemptCount(ip) >= LOGIN_RESTRICT_COUNT) {
+            throw new LockedException(
+                    MessageFormat.format(
+                            "{0}회 로그인 실패 시 {1}분간 로그인 하실 수 없습니다",
+                            LOGIN_RESTRICT_COUNT,
+                            LOGIN_RESTRICT_TIMEOUT_MILLS / 60000));
+        }
+    }
+
+    private String getIpFromRequest(HttpServletRequest request) {
+        return Optional.ofNullable(request.getHeader(PROXY_HEADER))
+                .orElse(request.getRemoteAddr());
+    }
+
+    private int getLoginAttemptCount(String ip) {
+        return Integer.parseInt(
+                Optional.ofNullable(redisProvider.getData(LOGIN_KEY_PREFIX + ip))
+                        .orElse("0"));
     }
 
 }

--- a/src/main/java/com/wnis/linkyway/service/email/EmailService.java
+++ b/src/main/java/com/wnis/linkyway/service/email/EmailService.java
@@ -1,6 +1,7 @@
 package com.wnis.linkyway.service.email;
 
 import com.wnis.linkyway.exception.common.EmailSendException;
+import com.wnis.linkyway.redis.RedisConstants;
 import com.wnis.linkyway.redis.RedisProvider;
 import com.wnis.linkyway.redis.values.EmailVerificationValue;
 import lombok.RequiredArgsConstructor;
@@ -13,6 +14,8 @@ import org.springframework.stereotype.Service;
 import java.util.Optional;
 import java.util.UUID;
 
+import static com.wnis.linkyway.redis.RedisConstants.*;
+
 @Slf4j
 @Service
 @RequiredArgsConstructor
@@ -22,7 +25,6 @@ public class EmailService {
     private final RedisProvider redisProvider;
 
     private static final String VERIFICATION_SUBJECT = "LinkyWay 에서 이메일 인증코드 발송";
-    private static final long EMAIL_VALIDATION_EXPIRATION_TIME = 1000 * 60 * 15;
 
     public void confirmVerificationCode(String email, String code) {
         EmailVerificationValue emailVerification = redisProvider.getData(email, EmailVerificationValue.class);


### PR DESCRIPTION
<br>

![image](https://user-images.githubusercontent.com/76927397/174778865-6395b873-7d1f-4c47-9982-deb8419323d4.png)

<br>

**추가사항**

- 우선 로그인 `5`회 `5` 분간 제한하도록 함

- 로그인 실패 시 redis에 해당 ip 의 로그인 실패 기록을 저장함 

- 로그인 인증 필터로 로그인 요청이 들어왔을 때 해당 IP 의 redis에 저장된 로그인 요청 횟수를 검사하여 5회 이상일 경우 로그인을 제한함