### PR TITLE
비인증 회원 비밀번호 찾기 기능 추가

### DIFF
--- a/src/main/java/com/wnis/linkyway/controller/MemberController.java
+++ b/src/main/java/com/wnis/linkyway/controller/MemberController.java
@@ -78,6 +78,15 @@ public class MemberController {
         MemberResponse response = memberService.updatePassword(passwordRequest, memberId);
         return ResponseEntity.ok(Response.of(HttpStatus.OK, response, "패스워드 변경 성공"));
     }
+
+    @PutMapping("/password/noauth")
+    @ApiOperation(value = "비인증 회원 비밀번호 수정", notes = "비밀번호를 잊은 사용자의 비밀번호를 수정한다")
+    @WithEmailVerification
+    public ResponseEntity<Response<Object>> updatePasswordByVerifiedEmail(
+            @Validated(ValidationSequence.class) @RequestBody PasswordByEmailRequest passwordRequest) {
+        memberService.updatePasswordByVerifiedEmail(passwordRequest.getPassword(), passwordRequest.getEmail());
+        return ResponseEntity.ok(Response.of(HttpStatus.OK, "패스워드 변경 성공"));
+    }
     
     @DeleteMapping
     @ApiOperation(value = "회원 탈퇴", notes = "회원을 삭제한다")

--- a/src/main/java/com/wnis/linkyway/controller/MemberController.java
+++ b/src/main/java/com/wnis/linkyway/controller/MemberController.java
@@ -22,7 +22,7 @@ public class MemberController {
     private final MemberService memberService;
     
     @PostMapping
-    @ApiOperation(value = "회원가입", notes = "회원정보를 입력해 회원가입(같은 IP로 N회 이상 요청 불가능하다)")
+    @ApiOperation(value = "회원가입", notes = "회원정보를 입력해 회원가입")
     @WithEmailVerification
     public ResponseEntity<Response> join(
             @Validated(ValidationSequence.class) @RequestBody JoinRequest joinRequest) {
@@ -31,7 +31,7 @@ public class MemberController {
     }
     
     @PostMapping("/login")
-    @ApiOperation(value = "로그인", notes = "로그인 이후 JWT 토큰 리턴(같은 IP로 N회 이상 요청 불가능하다)")
+    @ApiOperation(value = "로그인", notes = "로그인 이후 JWT 토큰 리턴")
     public ResponseEntity<Void> login(@RequestBody LoginRequest loginRequest) {
         return ResponseEntity.ok().build();
     }

--- a/src/main/java/com/wnis/linkyway/dto/Response.java
+++ b/src/main/java/com/wnis/linkyway/dto/Response.java
@@ -19,4 +19,8 @@ public class Response<T> {
         return new Response<>(httpStatus.value(), data, message);
     }
 
+    public static <T> Response<T> of(HttpStatus httpStatus, String message) {
+        return new Response<>(httpStatus.value(), null, message);
+    }
+
 }

--- a/src/main/java/com/wnis/linkyway/dto/member/PasswordByEmailRequest.java
+++ b/src/main/java/com/wnis/linkyway/dto/member/PasswordByEmailRequest.java
@@ -1,0 +1,25 @@
+package com.wnis.linkyway.dto.member;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import javax.validation.constraints.NotBlank;
+import javax.validation.constraints.Pattern;
+
+import static com.wnis.linkyway.validation.ValidationGroup.*;
+
+@Getter
+@NoArgsConstructor
+public class PasswordByEmailRequest extends PasswordRequest {
+
+    @NotBlank(message = "email을 입력해주세요.", groups = NotBlankGroup.class)
+    @Pattern(regexp = "^[a-zA-Z\\d]+@[a-zA-Z0-9-]+\\.[a-zA-Z0-9-.]+$",
+            message = "email 형식을 확인해주세요",
+            groups = PatternCheckGroup.class)
+    private String email;
+
+    public PasswordByEmailRequest(String email, String password) {
+        super(password);
+        this.email = email;
+    }
+}

--- a/src/main/java/com/wnis/linkyway/dto/member/PasswordRequest.java
+++ b/src/main/java/com/wnis/linkyway/dto/member/PasswordRequest.java
@@ -19,5 +19,6 @@ public class PasswordRequest {
     @Pattern(regexp = "^(?=.*[A-Z])(?=.*[a-z])(?=.*[0-9])(?=.*\\W)(?=\\S+$).{4,16}$",
              message = "최소 대/소 문자 하나, 숫자 하나, 특수문자를 4 ~ 16 글자로 입력해주세요",
              groups = ValidationGroup.PatternCheckGroup.class)
-    String password;
+    private String password;
+    
 }

--- a/src/main/java/com/wnis/linkyway/service/MemberService.java
+++ b/src/main/java/com/wnis/linkyway/service/MemberService.java
@@ -20,14 +20,13 @@ public class MemberService {
     private final MemberRepository memberRepository;
 
     private final FolderRepository folderRepository;
-    
+
     private final PasswordEncoder passwordEncoder;
 
     @Transactional(readOnly = true)
     public Member login(LoginRequest loginRequest) {
-        Member member = memberRepository.findByEmail(loginRequest.getEmail())
-                                        .orElseThrow(() -> new UsernameNotFoundException("이메일 또는 비밀번호를 확인하세요"));
-        
+        Member member = getMemberByEmail(loginRequest.getEmail(),
+                new UsernameNotFoundException("이메일 또는 비밀번호를 확인하세요"));
         validPassword(loginRequest.getPassword(), member.getPassword());
         return member;
     }
@@ -42,40 +41,38 @@ public class MemberService {
                 .password(joinRequest.getPassword())
                 .email(joinRequest.getEmail())
                 .build();
-        
+
         joinMember.changePassword(passwordEncoder.encode(joinMember.getPassword()));
 
         memberRepository.save(joinMember);
         folderRepository.addSuperFolder(joinMember.getId());
-        
+
         return MemberResponse.from(joinMember);
     }
 
     @Transactional
     public MemberResponse searchEmail(String email) {
-        Member member = memberRepository.findByEmail(email)
-                                        .orElseThrow(() -> new NotFoundEntityException("조회한 이메일이 존재하지 않습니다"));
-
+        Member member = getMemberByEmail(email);
         return MemberResponse.builder().email(member.getEmail()).build();
     }
 
     @Transactional
     public MemberResponse searchMyPage(Long memberId) {
         Member member = memberRepository.findById(memberId)
-                                        .orElseThrow(() -> new NotFoundEntityException("회원을 찾을 수 없습니다"));
+                .orElseThrow(() -> new NotFoundEntityException("회원을 찾을 수 없습니다"));
 
         return MemberResponse.from(member);
     }
-    
+
     @Transactional
     public MemberResponse updateMyPage(UpdateMemberRequest updateMemberRequest, Long memberId) {
-        validNicknameDuplication(updateMemberRequest.getNickname())
-        
+        validNicknameDuplication(updateMemberRequest.getNickname());
+
         Member member = memberRepository.findById(memberId)
                 .orElseThrow(() -> new NotFoundEntityException("회원을 찾을 수 없습니다"));
-        
+
         member.updateNickname(updateMemberRequest.getNickname());
-        
+
         return MemberResponse.builder()
                 .memberId(memberId)
                 .nickname(member.getNickname())
@@ -85,17 +82,23 @@ public class MemberService {
     @Transactional
     public MemberResponse updatePassword(PasswordRequest passwordRequest, Long memberId) {
         Member member = memberRepository.findById(memberId)
-                                        .orElseThrow(() -> new NotModifyEmptyEntityException(
-                                                "회원이 존재하지 않아 비밀번호를 바꿀 수 없습니다"));
+                .orElseThrow(() -> new NotModifyEmptyEntityException(
+                        "회원이 존재하지 않아 비밀번호를 바꿀 수 없습니다"));
         member.changePassword(passwordEncoder.encode(passwordRequest.getPassword()));
         return MemberResponse.builder().build();
+    }
+
+    @Transactional
+    public void updatePasswordByVerifiedEmail(String password, String email) {
+        Member member = getMemberByEmail(email);
+        member.changePassword(passwordEncoder.encode(password));
     }
 
     @Transactional
     public MemberResponse deleteMember(Long memberId) {
         Member member = memberRepository.findById(memberId).orElseThrow(() ->
                 new NotDeleteEmptyEntityException("삭제 할 수 없습니다"));
-        
+
         memberRepository.deleteById(memberId);
         return MemberResponse.builder().build();
     }
@@ -106,6 +109,16 @@ public class MemberService {
         }
 
         return new DuplicationResponse(!memberRepository.existsByNickname(nickname));
+    }
+
+    private Member getMemberByEmail(String email, RuntimeException e) {
+        return memberRepository.findByEmail(email)
+                .orElseThrow(() -> e);
+    }
+
+    private Member getMemberByEmail(String email) {
+        return memberRepository.findByEmail(email)
+                .orElseThrow(() -> new NotFoundEntityException("존재하지 않는 회원입니다"));
     }
 
     private void validNicknameDuplication(String nickname) {

--- a/src/test/java/com/wnis/linkyway/controller/member/MemberControllerTest.java
+++ b/src/test/java/com/wnis/linkyway/controller/member/MemberControllerTest.java
@@ -1,11 +1,14 @@
 package com.wnis.linkyway.controller.member;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.wnis.linkyway.controller.MemberController;
+import com.wnis.linkyway.dto.member.PasswordByEmailRequest;
 import com.wnis.linkyway.dto.member.UpdateMemberRequest;
 import com.wnis.linkyway.exception.common.NotAddDuplicateEntityException;
 import com.wnis.linkyway.exception.common.NotFoundEntityException;
 import com.wnis.linkyway.service.MemberService;
+import com.wnis.linkyway.util.cookie.CookieConstants;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
@@ -21,6 +24,8 @@ import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.setup.MockMvcBuilders;
 import org.springframework.web.context.WebApplicationContext;
 
+import javax.servlet.http.Cookie;
+
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.doThrow;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put;
@@ -28,72 +33,89 @@ import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 @WebMvcTest(controllers = MemberController.class,
-        excludeFilters = { @ComponentScan.Filter(type = FilterType.ASSIGNABLE_TYPE,
-                classes = WebSecurityConfigurerAdapter.class) })
+        excludeFilters = {@ComponentScan.Filter(type = FilterType.ASSIGNABLE_TYPE,
+                classes = WebSecurityConfigurerAdapter.class)})
 public class MemberControllerTest {
-    
+
     @Autowired
     MockMvc mockMvc;
-    
+
     @MockBean
     MemberService memberService;
-    
+
     @Autowired
     WebApplicationContext ctx;
-    
+
     @Autowired
     ObjectMapper objectMapper;
-    
+
     @BeforeEach
     void setUp() {
         mockMvc = MockMvcBuilders.webAppContextSetup(ctx)
-                                 .alwaysDo(print())
-                                 .build();
+                .alwaysDo(print())
+                .build();
     }
-    
-    
+
+
     @Nested
     @DisplayName("회원 수정")
     class updateMemberTest {
-        
+
         @Test
         @DisplayName("입력 Validation 테스트")
         void shouldReturnStatus400_WhenInvalidInputTest() throws Exception {
             UpdateMemberRequest updateMemberRequest = UpdateMemberRequest.builder()
                     .nickname("adksjflkajsdljaksdflksjflasdkfjsdjfjsalkjfasdfas").build();
-            
+
             mockMvc.perform(put("/api/members/page/me")
-                                    .contentType(MediaType.APPLICATION_JSON)
-                                    .content(objectMapper.writeValueAsString(updateMemberRequest)))
-                   .andExpect(status().is(400));
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content(objectMapper.writeValueAsString(updateMemberRequest)))
+                    .andExpect(status().is(400));
         }
-    
+
         @Test
         @DisplayName("닉네임 중복시 테스트")
         void shouldReturnStatus409_WhenThrowDuplicateNicknameTest() throws Exception {
             UpdateMemberRequest updateMemberRequest = UpdateMemberRequest.builder()
-                                                                         .nickname("hello").build();
-    
+                    .nickname("hello").build();
+
             doThrow(new NotAddDuplicateEntityException("h")).when(memberService).updateMyPage(any(), any());
-            
+
             mockMvc.perform(put("/api/members/page/me")
-                                    .contentType(MediaType.APPLICATION_JSON)
-                                    .content(objectMapper.writeValueAsString(updateMemberRequest)))
-                   .andExpect(status().isConflict());
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content(objectMapper.writeValueAsString(updateMemberRequest)))
+                    .andExpect(status().isConflict());
         }
-    
+
         @Test
         @DisplayName("회원 정보가 없을 시 테스트")
         void shouldReturnStatus404_WhenThrowNotFoundIDTest() throws Exception {
             UpdateMemberRequest updateMemberRequest = UpdateMemberRequest.builder()
-                                                                         .nickname("hello").build();
-        
+                    .nickname("hello").build();
+
             doThrow(new NotFoundEntityException(" ")).when(memberService).updateMyPage(any(), any());
-        
+
             mockMvc.perform(put("/api/members/page/me")
-                                    .contentType(MediaType.APPLICATION_JSON)
-                                    .content(objectMapper.writeValueAsString(updateMemberRequest)))
-                   .andExpect(status().is(404));
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content(objectMapper.writeValueAsString(updateMemberRequest)))
+                    .andExpect(status().is(404));
         }
+    }
+
+    @Nested
+    @DisplayName("비인증 회원의 이메일 인증으로의 비밀번호 변경")
+    class SetPasswordByEmailTest {
+
+        @Test
+        @DisplayName("인증된 이메일로의 비밀번호 변경 요청이 성공한다")
+        void shouldReturnStatus200_WhenRequestWithVerifiedEmail() throws Exception {
+            Cookie cookie = new Cookie(CookieConstants.VERIFICATION_COOKIE_NAME, "marraas1101@naver.com");
+            PasswordByEmailRequest request = new PasswordByEmailRequest("marraas1101@naver.com", "Aa1!");
+            mockMvc.perform(put("/api/members/password/noauth")
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content(objectMapper.writeValueAsString(request)))
+                    .andExpect(status().isOk());
+        }
+
     }
 }

--- a/src/test/java/com/wnis/linkyway/service/MemberServiceTest.java
+++ b/src/test/java/com/wnis/linkyway/service/MemberServiceTest.java
@@ -6,7 +6,9 @@ import com.wnis.linkyway.dto.member.JoinRequest;
 import com.wnis.linkyway.dto.member.MemberResponse;
 import com.wnis.linkyway.dto.member.PasswordRequest;
 import com.wnis.linkyway.dto.member.UpdateMemberRequest;
+import com.wnis.linkyway.entity.Member;
 import com.wnis.linkyway.exception.common.*;
+import com.wnis.linkyway.repository.MemberRepository;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
@@ -17,6 +19,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.test.context.jdbc.Sql;
 
 import javax.transaction.Transactional;
@@ -31,11 +34,16 @@ class MemberServiceTest {
 
     private final Logger logger = LoggerFactory.getLogger(MemberServiceTest.class);
     @Autowired
-    MemberService memberService;
-    
+    private MemberService memberService;
 
     @Autowired
-    ObjectMapper objectMapper;
+    private MemberRepository memberRepository;
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    @Autowired
+    private PasswordEncoder passwordEncoder;
 
     @Nested
     @DisplayName("회원가입")
@@ -51,7 +59,7 @@ class MemberServiceTest {
                                                  .build();
 
             MemberResponse response = memberService.join(joinRequest);
-            
+
             assertThat(response.getEmail()).isNotNull();
             assertThat(response.getMemberId()).isNotNull();
             assertThat(response.getNickname()).isNotNull();
@@ -95,8 +103,7 @@ class MemberServiceTest {
             String email = "aaasdbadafdaf@naver.com";
             assertThatThrownBy(() -> {
                 memberService.searchEmail(email);
-            }).isInstanceOf(ResourceNotFoundException.class)
-              .hasMessage("조회한 이메일이 존재하지 않습니다");
+            }).isInstanceOf(ResourceNotFoundException.class);
         }
     }
 
@@ -110,7 +117,7 @@ class MemberServiceTest {
             Long memberId = 1L;
             MemberResponse response = memberService.searchMyPage(memberId);
             logger.info(objectMapper.writeValueAsString(response));
-    
+
             assertThat(response).extracting("memberId").isNotNull();
             assertThat(response).extracting("email").isNotNull();
             assertThat(response).extracting("nickname").isNotNull();
@@ -127,11 +134,11 @@ class MemberServiceTest {
 
         }
     }
-    
+
     @Nested
     @DisplayName("마이페이지 수정")
     class UpdateMemberTest {
-        
+
         @Test
         @DisplayName("응답 테스트")
         void shouldReturnIdAndUpdatedNicknameWhenResponseTest() {
@@ -140,12 +147,12 @@ class MemberServiceTest {
                     .nickname("쿠로사키 2치고").build();
             // when
             MemberResponse memberResponse = memberService.updateMyPage(updateMemberRequest, 1L);
-            
+
             // then
             assertThat(memberResponse.getMemberId()).isNotNull();
             assertThat(memberResponse.getNickname()).isNotNull();
         }
-        
+
         @Test
         @DisplayName("닉네임 중복 여부")
         void shouldThrowDuplicateException_WhenInputDuplicateNicknameTest() {
@@ -153,21 +160,21 @@ class MemberServiceTest {
             UpdateMemberRequest updateMemberRequest = UpdateMemberRequest.builder()
                     .nickname("Zeratu6")
                     .build();
-            
-            
+
+
             assertThatThrownBy(()-> {
                 // when
                 memberService.updateMyPage(updateMemberRequest, 1L);
             }).isInstanceOf(NotAddDuplicateEntityException.class); // then
         }
-        
+
         @Test
         @DisplayName("회원입력이 옳바르지 않은 경우")
         void shouldThrowNotFoundException_WhenInputInvalidMemberIdTest() {
             // given
             UpdateMemberRequest updateMemberRequest = UpdateMemberRequest.builder()
                          .nickname("손흥민").build();
-    
+
             assertThatThrownBy(()-> {
                 // when
                 memberService.updateMyPage(updateMemberRequest, 100L);
@@ -189,7 +196,7 @@ class MemberServiceTest {
             MemberResponse response = memberService.updatePassword(passwordRequest, memberId);
 
             logger.info(objectMapper.writeValueAsString(response));
-    
+
             assertThat(response).extracting("memberId").isNull();
             assertThat(response).extracting("email").isNull();
             assertThat(response).extracting("nickname").isNull();
@@ -207,6 +214,22 @@ class MemberServiceTest {
                 memberService.updatePassword(passwordRequest, memberId);
             }).isInstanceOf(ResourceConflictException.class)
               .hasMessage("회원이 존재하지 않아 비밀번호를 바꿀 수 없습니다");
+        }
+    }
+
+    @Nested
+    @DisplayName("비인증 상황에서 이메일 인증 후 패스워드 변경 동작 테스트")
+    class SetPasswordTestByVerfiedEmail {
+
+        private final String EXIST_EMAIL = "marrin1101@hanmail.com";
+        private final String REQUEST_PASSWORD = "aasd!@!asdA";
+
+        @Test
+        @DisplayName("존재하는 회원(이메일)로의 요청으로 정상적으로 비밀번호 변경이 수행된다.")
+        void shouldDoChangePasswordByEmail() {
+            memberService.updatePasswordByVerifiedEmail("aasd!@!asdA",EXIST_EMAIL);
+            Member member = memberRepository.findByEmail(EXIST_EMAIL).orElse(null);
+            assertThat(passwordEncoder.matches(REQUEST_PASSWORD,member.getPassword())).isTrue();
         }
     }
 


### PR DESCRIPTION

### 추가사항

**api 추가**

- 비회원이 비밀번호를 잊어버렸을 때 이메일 검증 후 비밀번호를 재설정 할 수 있도록 하는 api 추가

> 적절한 네이밍이 떠오르지 않아 다음처럼 설정

- `POST: /api/members/password/noauth`
 

**MemberController 의 불필요 api 문서 설명 제거**

`(같은 IP로 N회 이상 요청 불가능하다))`

- 여러 방법 중 하나 또는 여러개를 써서 로그인 제한을 줄 수 있음.
- 그 중 정한 제한 정책을 굳이 사용자한테 노출시킬 필요 없음
