### PR TITLE
폴더 경로 이동 관련 개선 

### DIFF
--- a/src/main/java/com/wnis/linkyway/controller/FolderController.java
+++ b/src/main/java/com/wnis/linkyway/controller/FolderController.java
@@ -36,8 +36,8 @@ public class FolderController {
     @GetMapping("/{folderId}")
     @ApiOperation(value = "폴더 조회", notes = "해당 회원이 가지고 있는 폴더를 ID를 통해 조회한다")
     @Authenticated
-    public ResponseEntity<Response<FolderResponse>> searchFolder(@PathVariable(value = "folderId") Long folderId) {
-        FolderResponse response = folderService.findFolder(folderId);
+    public ResponseEntity<Response<FolderResponse>> searchFolder(@PathVariable(value = "folderId") Long folderId, @CurrentMember Long memberId) {
+        FolderResponse response = folderService.findFolder(folderId, memberId);
         return ResponseEntity.ok(Response.of(HttpStatus.OK, response, "폴더를 성공적으로 조회했습니다"));
     }
 
@@ -57,9 +57,9 @@ public class FolderController {
     @Authenticated
     public ResponseEntity<Response<FolderResponse>> updateFolderName(
             @Validated(ValidationSequence.class) @RequestBody UpdateFolderNameRequest updateFolderNameRequest,
-            @PathVariable Long folderId) {
+            @PathVariable Long folderId, @CurrentMember Long memberId) {
 
-        FolderResponse response = folderService.updateFolderName(updateFolderNameRequest, folderId);
+        FolderResponse response = folderService.updateFolderName(updateFolderNameRequest, folderId, memberId);
         return ResponseEntity.ok(Response.of(HttpStatus.OK, response, "폴더 이름이 성공적으로 수정되었습니다"));
     }
 
@@ -68,17 +68,17 @@ public class FolderController {
     @Authenticated
     public ResponseEntity<Response<FolderResponse>> updateFolderPath(
             @Validated(ValidationSequence.class) @RequestBody UpdateFolderPathRequest updateFolderPathRequest,
-            @PathVariable(value = "folderId") Long folderId) {
+            @PathVariable(value = "folderId") Long folderId, @CurrentMember Long memberId) {
 
-        FolderResponse response = folderService.updateFolderPath(updateFolderPathRequest, folderId);
+        FolderResponse response = folderService.updateFolderPath(updateFolderPathRequest, folderId, memberId);
         return ResponseEntity.ok(Response.of(HttpStatus.OK, response, "폴더 경로가 성공적으로 수정되었습니다"));
     }
 
     @DeleteMapping("/{folderId}")
     @ApiOperation(value = "폴더 삭제", notes = "해당 폴더를 삭제한다")
     @Authenticated
-    public ResponseEntity<Response<FolderResponse>> deleteFolder(@PathVariable(value = "folderId") Long folderId) {
-        FolderResponse response = folderService.deleteFolder(folderId);
+    public ResponseEntity<Response<FolderResponse>> deleteFolder(@PathVariable(value = "folderId") Long folderId, @CurrentMember Long memberId) {
+        FolderResponse response = folderService.deleteFolder(folderId, memberId);
         return ResponseEntity.ok(Response.of(HttpStatus.OK, response, "폴더와 하위 폴더가 성공적으로 삭제되었습니다"));
     }
 }

--- a/src/main/java/com/wnis/linkyway/dto/folder/UpdateFolderPathRequest.java
+++ b/src/main/java/com/wnis/linkyway/dto/folder/UpdateFolderPathRequest.java
@@ -1,9 +1,7 @@
 package com.wnis.linkyway.dto.folder;
 
-import com.wnis.linkyway.validation.ValidationGroup.NotBlankGroup;
 import lombok.*;
 
-import javax.validation.constraints.NotNull;
 import javax.validation.constraints.Positive;
 
 @Getter
@@ -12,7 +10,6 @@ import javax.validation.constraints.Positive;
 @NoArgsConstructor
 public class UpdateFolderPathRequest {
 
-    @NotNull(message = "타겟 상위 폴더의 id를 입력해주세요", groups = NotBlankGroup.class)
-    @Positive(message = "targetFolderId는 1 이상의 id를 입력하셔야 합니다.")
+    @Positive(message = "올바른 목표 폴더 id를 입력하세요")
     private Long targetFolderId;
 }

--- a/src/main/java/com/wnis/linkyway/entity/Folder.java
+++ b/src/main/java/com/wnis/linkyway/entity/Folder.java
@@ -73,14 +73,15 @@ public class Folder {
         }
 
         // 기존 부모 자식연결 부분에서 현재 폴더 엔티티 제거
-        Folder parent = this.getParent();
-        parent.getChildren()
-              .removeIf((f) -> f.getId() == this.getId());
-
+        Folder parent = this.parent;
+        if(parent != null){
+            parent.getChildren()
+                    .removeIf((f) -> f.getId() == this.getId());
+        }
         this.parent = destination; // 현재 폴더의 부모를 destination 설정
+        this.depth = destination.depth + 1;
         destination.getChildren()
                    .add(this); // destination 자식에 현재 폴더 엔티티 추가
-
     }
 
     public boolean isDirectAncestor(Folder folder) {

--- a/src/main/java/com/wnis/linkyway/entity/Folder.java
+++ b/src/main/java/com/wnis/linkyway/entity/Folder.java
@@ -8,15 +8,16 @@ import lombok.Setter;
 import javax.persistence.*;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Optional;
 
 @NoArgsConstructor
 @Getter
 @Entity
 @Table(name = "folder",
-indexes = {
-        @Index(name = "name", columnList = "name"),
-        @Index(name = "depth", columnList = "depth")
-})
+        indexes = {
+                @Index(name = "name", columnList = "name"),
+                @Index(name = "depth", columnList = "depth")
+        })
 public class Folder {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
@@ -28,7 +29,7 @@ public class Folder {
     private String name;
 
     @Column(name = "depth", nullable = false)
-    private Long depth;
+    private long depth;
 
     //// ********************연관 관게 ***************************/////
 
@@ -58,30 +59,64 @@ public class Folder {
         this.parent = parent;
         if (parent != null)
             parent.getChildren()
-                  .add(this);
+                    .add(this);
 
         this.member = member;
         if (member != null) {
             member.getFolders()
-                  .add(this);
+                    .add(this);
         }
     }
 
-    public void modifyParent(Folder destination) {
+    public void modifyParent(Folder destination, long depth) {
         if (destination.isDirectAncestor(this)) {
             throw new IllegalStateException("순환 참조 위험성이 있습니다.");
         }
 
         // 기존 부모 자식연결 부분에서 현재 폴더 엔티티 제거
-        Folder parent = this.parent;
-        if(parent != null){
-            parent.getChildren()
-                    .removeIf((f) -> f.getId() == this.getId());
-        }
+        removeParentConnection();
         this.parent = destination; // 현재 폴더의 부모를 destination 설정
-        this.depth = destination.depth + 1;
+        modifyChildrenFolderDepth(depth - this.depth + 1);
         destination.getChildren()
-                   .add(this); // destination 자식에 현재 폴더 엔티티 추가
+                .add(this); // destination 자식에 현재 폴더 엔티티 추가
+    }
+
+    private void removeParentConnection() {
+        Folder parentFolder = this.parent;
+        if (parentFolder != null) {
+            parentFolder.getChildren()
+                    .removeIf(folder -> folder.getId().equals(this.getId()));
+        }
+    }
+
+    private void modifyChildrenFolderDepth(long depthChangeAmount) {
+        changeRecursiveDepth(this, depthChangeAmount);
+    }
+
+    private void changeRecursiveDepth(Folder currentFolder, long depthChangeAmount) {
+        currentFolder.setDepth(depthChangeAmount);
+        if (currentFolder.children.isEmpty()) {
+            return;
+        }
+        currentFolder.children.forEach(folder -> changeRecursiveDepth(folder, depthChangeAmount));
+    }
+
+    public void deleteParent() {
+        this.parent = null;
+        modifyChildrenFolderDepth(-this.depth + 1);
+        removeParentConnection();
+    }
+
+    public int getDistanceOfFarthestChildren() {
+        return searchFolderDepth(this, 1, this.depth);
+    }
+
+    private int searchFolderDepth(Folder currentFolder, int max, long startDepth) {
+        if (currentFolder.children.isEmpty()) {
+            return max;
+        }
+        return currentFolder.children.stream().mapToInt(folder -> searchFolderDepth(
+                folder, (int) Math.max(currentFolder.depth - startDepth + 1, max + 1), startDepth)).max().getAsInt();
     }
 
     public boolean isDirectAncestor(Folder folder) {
@@ -100,5 +135,9 @@ public class Folder {
     public Folder updateName(String name) {
         this.name = name;
         return this;
+    }
+
+    public void setDepth(Long depth) {
+        this.depth += depth;
     }
 }

--- a/src/main/java/com/wnis/linkyway/entity/Folder.java
+++ b/src/main/java/com/wnis/linkyway/entity/Folder.java
@@ -95,16 +95,12 @@ public class Folder {
 
     private void changeRecursiveDepth(Folder currentFolder, long depthChangeAmount) {
         currentFolder.setDepth(depthChangeAmount);
-        if (currentFolder.children.isEmpty()) {
-            return;
-        }
         currentFolder.children.forEach(folder -> changeRecursiveDepth(folder, depthChangeAmount));
     }
 
     public void deleteParent() {
         this.parent = null;
         modifyChildrenFolderDepth(-this.depth + 1);
-        removeParentConnection();
     }
 
     public int getDistanceOfFarthestChildren() {

--- a/src/main/java/com/wnis/linkyway/service/folder/FolderService.java
+++ b/src/main/java/com/wnis/linkyway/service/folder/FolderService.java
@@ -11,13 +11,13 @@ public interface FolderService {
 
     List<FolderResponse> findAllFolderSuper(Long memberId);
 
-    FolderResponse findFolder(Long folderId);
+    FolderResponse findFolder(Long folderId, Long memberId);
 
     FolderResponse addFolder(AddFolderRequest addFolderRequest, Long memberId);
 
-    FolderResponse updateFolderPath(UpdateFolderPathRequest setFolderPathRequest, Long folderId);
+    FolderResponse updateFolderPath(UpdateFolderPathRequest setFolderPathRequest, Long folderId, Long memberId);
 
-    FolderResponse updateFolderName(UpdateFolderNameRequest setFolderNameRequest, Long folderId);
+    FolderResponse updateFolderName(UpdateFolderNameRequest setFolderNameRequest, Long folderId, Long memberId);
 
-    FolderResponse deleteFolder(Long folderId);
+    FolderResponse deleteFolder(Long folderId, Long memberId);
 }

--- a/src/main/resources/folder.yml
+++ b/src/main/resources/folder.yml
@@ -1,3 +1,3 @@
 folder:
   limit:
-    depth: 2
+    depth: 3

--- a/src/test/java/com/wnis/linkyway/controller/folder/FolderControllerIntegrationTest.java
+++ b/src/test/java/com/wnis/linkyway/controller/folder/FolderControllerIntegrationTest.java
@@ -261,10 +261,10 @@ public class FolderControllerIntegrationTest {
         @WithMockMember(id = 1L, email = "marrin1101@naver.com")
         void LimitFolderDepthTest() throws Exception {
             UpdateFolderPathRequest updateFolderPathRequest = UpdateFolderPathRequest.builder()
-                                                                            .targetFolderId(5L)
+                                                                            .targetFolderId(3L)
                                                                             .build();
 
-            MvcResult mvcResult = mockMvc.perform(put("/api/folders/3/path").contentType("application/json")
+            mockMvc.perform(put("/api/folders/1/path").contentType("application/json")
                                                                             .content(objectMapper.writeValueAsString(updateFolderPathRequest)))
                                          .andExpect(status().is(409))
                                          .andReturn();
@@ -288,28 +288,11 @@ public class FolderControllerIntegrationTest {
         }
 
         @Test
-        @DisplayName("목표 부모 폴더가 없는 경우 테스트")
-        @WithMockMember(id = 1L, email = "marrin1101@naver.com")
-        void NotExistTargetFolderTest() throws Exception {
-            UpdateFolderPathRequest setFolderPathRequest = UpdateFolderPathRequest.builder()
-                                                                            .targetFolderId(100L)
-                                                                            .build();
-
-            MvcResult mvcResult = mockMvc.perform(put("/api/folders/1/path").contentType("application/json")
-                                                                            .content(objectMapper.writeValueAsString(setFolderPathRequest)))
-                                         .andExpect(status().is(409))
-                                         .andReturn();
-
-            logger.info(mvcResult.getResponse()
-                                 .getContentAsString());
-        }
-
-        @Test
         @DisplayName("목표부모가 직계후손인 경우 테스트")
         @WithMockMember(id = 1L, email = "marrin1101@naver.com")
         void TargetFolderIsDirectDescendantFolderTest() throws Exception {
             UpdateFolderPathRequest setFolderPathRequest = UpdateFolderPathRequest.builder()
-                                                                            .targetFolderId(3L)
+                                                                            .targetFolderId(5L)
                                                                             .build();
 
             MvcResult mvcResult = mockMvc.perform(put("/api/folders/1/path").contentType("application/json")

--- a/src/test/java/com/wnis/linkyway/dto/folder/UpdateFolderPathRequestTest.java
+++ b/src/test/java/com/wnis/linkyway/dto/folder/UpdateFolderPathRequestTest.java
@@ -1,6 +1,5 @@
 package com.wnis.linkyway.dto.folder;
 
-import com.wnis.linkyway.validation.ValidationGroup;
 import org.hibernate.validator.internal.engine.ConstraintViolationImpl;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
@@ -31,21 +30,6 @@ class UpdateFolderPathRequestTest {
     @AfterAll
     static void close() {
         factory.close();
-    }
-
-    @Test
-    @DisplayName("Not Blank 테스트")
-    void notBlankTest() {
-        UpdateFolderPathRequest updateFolderPathRequest = UpdateFolderPathRequest.builder()
-                                                                        .build();
-
-        Set<ConstraintViolation<UpdateFolderPathRequest>> constraintViolations = validator.validate(updateFolderPathRequest,
-                                                                                                 ValidationGroup.NotBlankGroup.class);
-
-        constraintViolations.forEach((e) -> {
-            logger.info(e.getMessage());
-            assertThat(e).isInstanceOf(ConstraintViolationImpl.class);
-        });
     }
 
     @Test

--- a/src/test/java/com/wnis/linkyway/repository/FolderRepositoryTest.java
+++ b/src/test/java/com/wnis/linkyway/repository/FolderRepositoryTest.java
@@ -138,7 +138,7 @@ class FolderRepositoryTest {
         Folder folder6 = folderRepository.findFolderById(5L)
                                          .get();
 
-        folder2.modifyParent(folder6);
+        folder2.modifyParent(folder6, folder6.getDepth());
 
         // 트랜잭션 전에 DB로 바로 flush
         folderRepository.saveAndFlush(folder2);
@@ -183,7 +183,7 @@ class FolderRepositoryTest {
         Folder folder4 = folderRepository.findFolderById(4L)
                                          .get();
 
-        Assertions.assertThatThrownBy(() -> folder2.modifyParent(folder4))
+        Assertions.assertThatThrownBy(() -> folder2.modifyParent(folder4, folder4.getDepth()))
                   .isInstanceOf(IllegalStateException.class);
 
     }

--- a/src/test/java/com/wnis/linkyway/service/folder/FolderServiceImplTest.java
+++ b/src/test/java/com/wnis/linkyway/service/folder/FolderServiceImplTest.java
@@ -260,6 +260,18 @@ class FolderServiceImplTest {
                                                                  2L)).isInstanceOf(ResourceConflictException.class)
                                                                      .hasMessage("직계 자손을 목표 부모 폴더로 지정 할 수 없습니다");
         }
+
+        @Test
+        @DisplayName("최상위 경로로의 이동 요청에 대한 동작 테스트")
+        void changeRequestForSuperPathTest() {
+            UpdateFolderPathRequest updateFolderPathRequest = UpdateFolderPathRequest.builder().build();
+            FolderResponse folderResponse = folderService.updateFolderPath(updateFolderPathRequest, 3L);
+            assertThat(folderResponse).isNotNull();
+            assertThat(folderResponse.getParentId()).isNull();
+            Folder folder3 = folderRepository.findFolderById(3L).orElse(null);
+            assertThat(folder3).isNotNull();
+            assertThat(folder3.getParent()).isNull();
+        }
     }
 
     @Nested

--- a/src/test/java/com/wnis/linkyway/service/folder/FolderServiceImplTest.java
+++ b/src/test/java/com/wnis/linkyway/service/folder/FolderServiceImplTest.java
@@ -191,10 +191,11 @@ class FolderServiceImplTest {
         }
 
         @Test
-        @DisplayName("예외 테스트: 폴더 깊이가 2를 초과하는 경우")
+        @DisplayName("예외 테스트: 폴더 깊이가 M을 초과하는 경우")
         void exceptionTest3() {
+            int maxFolderDepth = 3;
             AddFolderRequest addFolderRequest = AddFolderRequest.builder()
-                                                                .parentFolderId(3L)
+                                                                .parentFolderId(4L)
                                                                 .name("뻐꾸기")
                                                                 .build();
 

--- a/src/test/java/com/wnis/linkyway/service/folder/FolderServiceImplTest.java
+++ b/src/test/java/com/wnis/linkyway/service/folder/FolderServiceImplTest.java
@@ -33,7 +33,7 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 @DataJpaTest
 @AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
 @Sql("/sqltest/initialize-test.sql")
-@Import({ FolderServiceImpl.class, ObjectMapper.class })
+@Import({FolderServiceImpl.class, ObjectMapper.class})
 class FolderServiceImplTest {
 
     private final Logger logger = LoggerFactory.getLogger(FolderServiceImplTest.class);
@@ -43,50 +43,50 @@ class FolderServiceImplTest {
     FolderRepository folderRepository;
     @Autowired
     MemberRepository memberRepository;
-    
+
 
     @BeforeEach
     void setup() {
 
         Member member1 = Member.builder()
-                               .email("maee@naver.com")
-                               .nickname("serin")
-                               .password("a!aA212341")
-                               .build();
+                .email("maee@naver.com")
+                .nickname("serin")
+                .password("a!aA212341")
+                .build();
 
         Folder folder1 = Folder.builder()
-                               .member(member1)
-                               .name("f1")
-                               .depth(0L)
-                               .build();
+                .member(member1)
+                .name("f1")
+                .depth(0L)
+                .build();
 
         Folder folder2 = Folder.builder()
-                               .member(member1)
-                               .name("f2")
-                               .depth(1L)
-                               .parent(null)
-                               .build();
+                .member(member1)
+                .name("f2")
+                .depth(1L)
+                .parent(null)
+                .build();
 
         Folder folder3 = Folder.builder()
-                               .member(member1)
-                               .name("f3")
-                               .depth(2L)
-                               .parent(folder2)
-                               .build();
+                .member(member1)
+                .name("f3")
+                .depth(2L)
+                .parent(folder2)
+                .build();
 
         Folder folder4 = Folder.builder()
-                               .member(member1)
-                               .name("f4")
-                               .depth(3L)
-                               .parent(folder2)
-                               .build();
+                .member(member1)
+                .name("f4")
+                .depth(3L)
+                .parent(folder2)
+                .build();
 
         Folder folder6 = Folder.builder()
-                               .member(member1)
-                               .name("f6")
-                               .depth(2L)
-                               .parent(folder1)
-                               .build();
+                .member(member1)
+                .name("f6")
+                .depth(2L)
+                .parent(folder1)
+                .build();
 
         memberRepository.save(member1);
         folderRepository.saveAll(Arrays.asList(folder1, folder2, folder3, folder4, folder6));
@@ -124,19 +124,19 @@ class FolderServiceImplTest {
         @Test
         @DisplayName("응답 테스트")
         void responseTest() {
-            FolderResponse folderResponse = folderService.findFolder(1L);
+            FolderResponse folderResponse = folderService.findFolder(1L, 1L);
             assertThat(folderResponse.getFolderId()).isNotNull();
             assertThat(folderResponse.getName()).isNotNull();
             assertThat(folderResponse.getLevel()).isNotNull();
             assertThat(folderResponse.getChildFolderList()).isNotNull();
-            
+
         }
 
         @Test
         @DisplayName("핸들링 테스트")
         void exceptionTest() {
 
-            assertThatThrownBy(() -> folderService.findFolder(30L)).isInstanceOf(ResourceNotFoundException.class);
+            assertThatThrownBy(() -> folderService.findFolder(30L, 1L)).isInstanceOf(ResourceNotFoundException.class);
 
         }
 
@@ -150,44 +150,44 @@ class FolderServiceImplTest {
         @DisplayName("응답 테스트")
         void responseTest() {
             AddFolderRequest addFolderRequest = AddFolderRequest.builder()
-                                                                .parentFolderId(2L)
-                                                                .name("뻐꾸기")
-                                                                .build();
+                    .parentFolderId(2L)
+                    .name("뻐꾸기")
+                    .build();
 
             FolderResponse folderResponse = folderService.addFolder(addFolderRequest, 1L);
             logger.info(folderResponse.getName());
-            logger.info("folder level: {}",folderResponse.getLevel());
+            logger.info("folder level: {}", folderResponse.getLevel());
             logger.info("folder id: {}", folderResponse.getFolderId());
             assertThat(folderResponse.getFolderId()).isNotNull();
             assertThat(folderResponse.getName()).isNotNull();
             assertThat(folderResponse.getLevel()).isNotNull();
             assertThat(folderResponse.getChildFolderList()).isNotNull();
-            
+
         }
 
         @Test
         @DisplayName("예외 테스트: 존재하지 않는 폴더를 입력한 경우")
         void exceptionTest1() {
             AddFolderRequest addFolderRequest = AddFolderRequest.builder()
-                                                                .parentFolderId(100L)
-                                                                .name("뻐꾸기")
-                                                                .build();
+                    .parentFolderId(100L)
+                    .name("뻐꾸기")
+                    .build();
 
             assertThatThrownBy(() -> folderService.addFolder(addFolderRequest,
-                                                             1L)).isInstanceOf(ResourceNotFoundException.class);
+                    1L)).isInstanceOf(ResourceNotFoundException.class);
         }
 
         @Test
         @DisplayName("예외 테스트: 회원이 존재하지 않는 경우")
         void exceptionTest2() {
             AddFolderRequest addFolderRequest = AddFolderRequest.builder()
-                                                                .parentFolderId(1L)
-                                                                .name("뻐꾸기")
-                                                                .build();
+                    .parentFolderId(1L)
+                    .name("뻐꾸기")
+                    .build();
 
             assertThatThrownBy(() -> folderService.addFolder(addFolderRequest,
-                                                             100L)).isInstanceOf(ResourceNotFoundException.class)
-                                                                   .hasMessage("회원이 존재하지 않습니다");
+                    100L)).isInstanceOf(ResourceNotFoundException.class)
+                    .hasMessage("회원이 존재하지 않습니다");
         }
 
         @Test
@@ -195,24 +195,24 @@ class FolderServiceImplTest {
         void exceptionTest3() {
             int maxFolderDepth = 3;
             AddFolderRequest addFolderRequest = AddFolderRequest.builder()
-                                                                .parentFolderId(4L)
-                                                                .name("뻐꾸기")
-                                                                .build();
+                    .parentFolderId(4L)
+                    .name("뻐꾸기")
+                    .build();
 
             assertThatThrownBy(() -> folderService.addFolder(addFolderRequest,
-                                                             1L)).isInstanceOf(LimitDepthException.class);
+                    1L)).isInstanceOf(LimitDepthException.class);
         }
 
         @Test
         @DisplayName("예외 테스트: default 폴더 아래에 임의로 생성하는 경우")
         void exceptionTest4() {
             AddFolderRequest addFolderRequest = AddFolderRequest.builder()
-                                                                .parentFolderId(1L)
-                                                                .name("뻐꾸기")
-                                                                .build();
+                    .parentFolderId(1L)
+                    .name("뻐꾸기")
+                    .build();
 
             assertThatThrownBy(() -> folderService.addFolder(addFolderRequest,
-                                                             1L)).isInstanceOf(ResourceConflictException.class);
+                    1L)).isInstanceOf(ResourceConflictException.class);
         }
     }
 
@@ -224,28 +224,28 @@ class FolderServiceImplTest {
         @DisplayName("응답 테스트")
         void responseTest() {
             UpdateFolderPathRequest updateFolderPathRequest = UpdateFolderPathRequest.builder()
-                                                                                     .targetFolderId(2L)
-                                                                                     .build();
+                    .targetFolderId(2L)
+                    .build();
 
-            FolderResponse folderResponse = folderService.updateFolderPath(updateFolderPathRequest, 4L);
-    
+            FolderResponse folderResponse = folderService.updateFolderPath(updateFolderPathRequest, 4L, 1L);
+
             assertThat(folderResponse.getFolderId()).isNotNull();
             assertThat(folderResponse.getName()).isNotNull();
             assertThat(folderResponse.getLevel()).isNotNull();
             assertThat(folderResponse.getChildFolderList()).isNotNull();
-            
+
         }
 
         @Test
         @DisplayName("예외 테스트1")
         void exceptionTest1() {
             UpdateFolderPathRequest updateFolderPathRequest = UpdateFolderPathRequest.builder()
-                                                                            .targetFolderId(200L)
-                                                                            .build();
+                    .targetFolderId(200L)
+                    .build();
 
             assertThatThrownBy(() -> folderService.updateFolderPath(updateFolderPathRequest,
-                                                                 4L)).isInstanceOf(ResourceConflictException.class)
-                                                                     .hasMessage("목표 부모 폴더가 존재하지 않아 수정 작업을 진행할 수 없습니다");
+                    4L, 1L)).isInstanceOf(ResourceConflictException.class)
+                    .hasMessage("목표 부모 폴더가 존재하지 않아 수정 작업을 진행할 수 없습니다");
 
         }
 
@@ -253,19 +253,19 @@ class FolderServiceImplTest {
         @DisplayName("예외 테스트2")
         void exceptionTest2() {
             UpdateFolderPathRequest updateFolderPathRequest = UpdateFolderPathRequest.builder()
-                                                                            .targetFolderId(4L)
-                                                                            .build();
+                    .targetFolderId(4L)
+                    .build();
 
             assertThatThrownBy(() -> folderService.updateFolderPath(updateFolderPathRequest,
-                                                                 2L)).isInstanceOf(ResourceConflictException.class)
-                                                                     .hasMessage("직계 자손을 목표 부모 폴더로 지정 할 수 없습니다");
+                    2L, 1L)).isInstanceOf(ResourceConflictException.class)
+                    .hasMessage("직계 자손을 목표 부모 폴더로 지정 할 수 없습니다");
         }
 
         @Test
         @DisplayName("최상위 경로로의 이동 요청에 대한 동작 테스트")
         void changeRequestForSuperPathTest() {
             UpdateFolderPathRequest updateFolderPathRequest = UpdateFolderPathRequest.builder().build();
-            FolderResponse folderResponse = folderService.updateFolderPath(updateFolderPathRequest, 3L);
+            FolderResponse folderResponse = folderService.updateFolderPath(updateFolderPathRequest, 3L, 1L);
             assertThat(folderResponse).isNotNull();
             assertThat(folderResponse.getParentId()).isNull();
             Folder folder3 = folderRepository.findFolderById(3L).orElse(null);
@@ -282,25 +282,25 @@ class FolderServiceImplTest {
         @DisplayName("응답 테스트")
         void responseTest() {
             UpdateFolderNameRequest updateFolderNameRequest = UpdateFolderNameRequest.builder()
-                                                                                  .name("스프링")
-                                                                                  .build();
+                    .name("스프링")
+                    .build();
 
-            FolderResponse folderResponse = folderService.updateFolderName(updateFolderNameRequest, 1L);
-            
+            FolderResponse folderResponse = folderService.updateFolderName(updateFolderNameRequest, 1L, 1L);
+
             assertThat(folderResponse.getName()).isNotNull();
             assertThat(folderResponse.getFolderId()).isNotNull();
-            
+
         }
 
         @Test
         @DisplayName("예외 테스트")
         void exceptionTest() {
             UpdateFolderNameRequest updateFolderNameRequest = UpdateFolderNameRequest.builder()
-                                                                                  .name("스프링")
-                                                                                  .build();
+                    .name("스프링")
+                    .build();
             assertThatThrownBy(() -> folderService.updateFolderName(updateFolderNameRequest,
-                                                                 100L)).isInstanceOf(ResourceConflictException.class)
-                                                                       .hasMessage("해당 폴더가 존재하지 않아 수정을 할 수 없습니다");
+                    100L, 1L)).isInstanceOf(ResourceConflictException.class)
+                    .hasMessage("해당 폴더가 존재하지 않아 수정을 할 수 없습니다");
         }
     }
 
@@ -311,8 +311,8 @@ class FolderServiceImplTest {
         @Test
         @DisplayName("응답 테스트")
         void responseTest() {
-            FolderResponse folderResponse = folderService.deleteFolder(1L);
-            
+            FolderResponse folderResponse = folderService.deleteFolder(1L, 1L);
+
             assertThat(folderResponse.getFolderId()).isNotNull();
             assertThat(folderResponse.getName()).isNotNull();
         }
@@ -320,8 +320,8 @@ class FolderServiceImplTest {
         @Test
         @DisplayName("예외 테스트")
         void exceptionTest() {
-            assertThatThrownBy(() -> folderService.deleteFolder(100L)).isInstanceOf(ResourceConflictException.class)
-                                                                      .hasMessage("해당 폴더가 존재하지 않아 삭제 할 수 없습니다");
+            assertThatThrownBy(() -> folderService.deleteFolder(100L, 1L)).isInstanceOf(ResourceConflictException.class)
+                    .hasMessage("해당 폴더가 존재하지 않아 삭제 할 수 없습니다");
         }
     }
 }

--- a/src/test/resources/folder.yml
+++ b/src/test/resources/folder.yml
@@ -1,3 +1,3 @@
 folder:
   limit:
-    depth: 2
+    depth: 3


### PR DESCRIPTION

### 추가 및 변경사항

- #153 의풀더 경로 수정 도메인 로직 npe 방어 및 depth 변경 누락 수정

- 폴더 깊이 확장에 따라 경로 이동 관련 재귀적 처리 추가

- 폴더 api 에 대한 요청 시 해당 폴더 자원이 본인의 것인지에 대한 검증이 누락되어있어 추가 

<br>

**전달사항**

현규님 아마 #150 이거 폴더관련작업 겹쳐서 머지충돌날텐데 메소드 같은것 자체 수정이 겹치진 않을 거니까 합치실 때 둘다 반영해서 넣으시면 될 것 같습니다.

