### PR TITLE
fix: 이제 같은 조회와 수정이 같은 이름인 경우 예외를 발생하지 않음. 그러나 해당 id에 중복 네임이 존재하는 경우 예외

### DIFF
--- a/src/main/java/com/wnis/linkyway/service/tag/TagServiceImpl.java
+++ b/src/main/java/com/wnis/linkyway/service/tag/TagServiceImpl.java
@@ -3,10 +3,7 @@ package com.wnis.linkyway.service.tag;
 import com.wnis.linkyway.dto.tag.TagRequest;
 import com.wnis.linkyway.dto.tag.TagResponse;
 import com.wnis.linkyway.entity.Tag;
-import com.wnis.linkyway.exception.common.NotAddDuplicateEntityException;
-import com.wnis.linkyway.exception.common.NotFoundEntityException;
-import com.wnis.linkyway.exception.common.NotModifyEmptyEntityException;
-import com.wnis.linkyway.exception.common.ResourceNotFoundException;
+import com.wnis.linkyway.exception.common.*;
 import com.wnis.linkyway.repository.MemberRepository;
 import com.wnis.linkyway.repository.TagRepository;
 import lombok.RequiredArgsConstructor;
@@ -60,14 +57,20 @@ public class TagServiceImpl implements TagService {
                                .orElseThrow(() -> new NotFoundEntityException("해당 태그가 존재하지 않아 수정 할 수 없습니다"));
 
         checkRequestMyTag(memberId, tag, "해당 태그가 존재하지 않아 수정 할 수 없습니다");
-        
-        if (tagRepository.existsByMemberIdAndTagName(tagRequest.getTagName(), tagId)) {
-            throw new NotFoundEntityException("이미 존재하는 태그의 이름으로 수정 할 수 없습니다");
+    
+        log.info(tag.getName());
+        log.info(tagRequest.getTagName());
+        log.info("{}",tagRepository.existsByMemberIdAndTagName(tagRequest.getTagName(), memberId));
+       
+        // 원래 태그 이름과 요청 태그이름이 다르면 기존 태그가 회원이 가지고 있는지 조회
+        if (!tag.getName().equals(tagRequest.getTagName()) && tagRepository.existsByMemberIdAndTagName(tagRequest.getTagName(), memberId)) {
+            throw new NotModifyDuplicateException("중복되는 태그 이름으로 수정 할 수 없습니다");
         }
-
+        
         tag.updateName(tagRequest.getTagName())
            .updateIsPublic(Boolean.parseBoolean(tagRequest.getIsPublic()));
-
+        // 원래 태그 이름이 요청 태그 이름과 같다면 그냥 업데이트 진행(소셜만 업데이트 됨)
+        
         return TagResponse.builder()
                           .tagId(tag.getId())
                           .tagName(tag.getName())


### PR DESCRIPTION
# 특이사항

## 조회 결과

![image](https://user-images.githubusercontent.com/39326175/175842662-a0d1417c-9366-46b9-b358-aa650f30829e.png)

## 같은 네임으로 수정하는 경우 예외 발생 x

![image](https://user-images.githubusercontent.com/39326175/175842679-6919dc07-4f40-4567-ac9a-016456053122.png)

## 이미 해당 아이디에 태그 존재하는 경우 예외

![image](https://user-images.githubusercontent.com/39326175/175842699-bea40186-e37d-4033-aae9-1f8e0ab3e97d.png)