### PR TITLE
Feat/#176/social search

### DIFF
--- a/src/main/java/com/wnis/linkyway/controller/PackageController.java
+++ b/src/main/java/com/wnis/linkyway/controller/PackageController.java
@@ -4,6 +4,7 @@ import com.wnis.linkyway.dto.PackageResponse;
 import com.wnis.linkyway.dto.Response;
 import com.wnis.linkyway.service.PackageService;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Pageable;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
@@ -18,8 +19,10 @@ public class PackageController {
     private final PackageService packageService;
     
     @GetMapping("/social")
-    ResponseEntity<Response> searchSocialByTagName(@RequestParam(value = "tagName", required = false) String tagName) {
-        List<PackageResponse> allPackageByTagName = packageService.findAllPackageByTagName(tagName);
+    ResponseEntity<Response> searchSocialByTagName(@RequestParam(value = "tagName", required = false) String tagName,
+            @RequestParam(value = "isLike", required = false) boolean isLike,
+            Pageable pageable) {
+        List<PackageResponse> allPackageByTagName = packageService.findAllPackageByTagName(tagName,isLike, pageable);
         return ResponseEntity.ok(Response.of(HttpStatus.OK, allPackageByTagName, "개인 검색 성공"));
     }
     

--- a/src/main/java/com/wnis/linkyway/repository/CardTagRepository.java
+++ b/src/main/java/com/wnis/linkyway/repository/CardTagRepository.java
@@ -38,18 +38,11 @@ public interface CardTagRepository extends JpaRepository<CardTag, Long> {
     List<Long> findAllCardTagIdInTagSet(@Param(value = "tagIdSet") Set<Long> tagIdSet);
     
     
-    @Query("select new com.wnis.linkyway.dto.PackageDto(m.id, m.nickname, t.id, t.name) from CardTag ct join ct.tag t " +
-            "join t.member m " +
-            "where t.name like %:tagName%")
-    List<PackageDto> findAllPackageDtoByTagName(@Param(value = "tagName") String tagName);
-
-    @Query("select new com.wnis.linkyway.dto.PackageDto(m.id, m.nickname, t.id, t.name) from CardTag ct join ct.tag t " +
-            "join t.member m")
-    List<PackageDto> findAllPackageDto();
-    
     @Query("select ct.id from CardTag ct join ct.card c " +
             "where c.id in :ids")
     List<Long> findAllCardTagIdInCardIds(@Param(value = "ids") List<Long> cardIds);
     
-    
+    @Query("select c from CardTag ct join ct.card c join ct.tag t " +
+            "where t.id = :tagId and c.isPublic = true")
+    List<Card> findAllPublicCardByTagId(Long tagId);
 }

--- a/src/main/java/com/wnis/linkyway/repository/TagRepository.java
+++ b/src/main/java/com/wnis/linkyway/repository/TagRepository.java
@@ -2,6 +2,7 @@ package com.wnis.linkyway.repository;
 
 import com.wnis.linkyway.dto.tag.TagResponse;
 import com.wnis.linkyway.entity.Tag;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
@@ -24,4 +25,13 @@ public interface TagRepository extends JpaRepository<Tag, Long> {
     public Optional<Tag> findByIdAndMemberId(@Param(value = "memberId") Long memberId,
             @Param(value = "tagId") Long tagId);
     
+    @Query("select distinct t "
+            + "from Tag t join fetch t.member m " +
+            "where t.name like %:tagName%")
+    public List<Tag> findAllDistinctTagListLikeTagName(@Param(value = "tagName") String tagName, Pageable pageable);
+    
+    @Query("select distinct t "
+            + "from Tag t join fetch t.member m " +
+            "where t.name = :tagName")
+    public List<Tag> findAllDistinctTagListByTagName(@Param(value = "tagName") String tagName, Pageable pageable);
 }

--- a/src/test/java/com/wnis/linkyway/controller/PackageControllerTest.java
+++ b/src/test/java/com/wnis/linkyway/controller/PackageControllerTest.java
@@ -21,6 +21,7 @@ import java.util.ArrayList;
 import java.util.List;
 
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyBoolean;
 import static org.mockito.Mockito.doReturn;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
@@ -60,9 +61,9 @@ class PackageControllerTest {
                 .build();
         List<PackageResponse> responseList = new ArrayList<>();
         responseList.add(packageResponse);
-        doReturn(responseList).when(packageService).findAllPackageByTagName(any());
+        doReturn(responseList).when(packageService).findAllPackageByTagName(any(), anyBoolean(), any());
         
-        mockMvc.perform(get("/api/search/social").param("tagName", "hello"))
+        mockMvc.perform(get("/api/search/social?isLike=false").param("tagName", "hello"))
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$..memberId").isNotEmpty())
                 .andExpect(jsonPath("$..nickname").isNotEmpty())

--- a/src/test/java/com/wnis/linkyway/controller/PackageIntegrationTest.java
+++ b/src/test/java/com/wnis/linkyway/controller/PackageIntegrationTest.java
@@ -1,0 +1,60 @@
+package com.wnis.linkyway.controller;
+
+import com.wnis.linkyway.entity.Card;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.jdbc.Sql;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.context.WebApplicationContext;
+
+import javax.persistence.EntityManager;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@SpringBootTest
+@Transactional
+@AutoConfigureMockMvc
+@Sql("/sqltest/card-test.sql")
+public class PackageIntegrationTest {
+    
+    @Autowired
+    MockMvc mockMvc;
+    
+    @Autowired
+    WebApplicationContext ctx;
+    
+    @Autowired
+    EntityManager em;
+    
+    @BeforeEach
+    void setUp() {
+        mockMvc = MockMvcBuilders.webAppContextSetup(ctx)
+                                 .alwaysDo(print())
+                                 .build();
+    }
+    
+    @Test
+    @DisplayName("패키지 통합 테스트")
+    void responseTest() throws Exception {
+        Card card = em.find(Card.class, 1L);
+        card.updateIsPublic(true);
+        em.flush();
+        
+        mockMvc.perform(get("/api/search/social?isLike=true").param("tagName", "ja"))
+               .andExpect(status().isOk())
+               .andExpect(jsonPath("$..memberId").isNotEmpty())
+               .andExpect(jsonPath("$..nickname").isNotEmpty())
+               .andExpect(jsonPath("$..numberOfCard").isNotEmpty())
+               .andExpect(jsonPath("$..tagName").isNotEmpty())
+               .andExpect(jsonPath("$..tagId").isNotEmpty());
+    }
+}

--- a/src/test/java/com/wnis/linkyway/repository/CardTagRepositoryTest.java
+++ b/src/test/java/com/wnis/linkyway/repository/CardTagRepositoryTest.java
@@ -73,6 +73,14 @@ class CardTagRepositoryTest {
             .title("card")
             .build();
     
+    Card card3 = Card.builder()
+                     .folder(folder)
+                     .isPublic(true)
+                     .content("")
+                     .link("2")
+                     .title("card")
+                     .build();
+    
     CardTag cardTag1 = CardTag.builder()
                               .card(card)
                               .tag(tag1)
@@ -88,6 +96,11 @@ class CardTagRepositoryTest {
             .tag(tag2)
             .build();
     
+    CardTag cardTag4 = CardTag.builder()
+                              .card(card3)
+                              .tag(tag1)
+                              .build();
+    
     @BeforeEach
     void setUp() {
         em.persist(member);
@@ -96,9 +109,11 @@ class CardTagRepositoryTest {
         em.persist(tag2);
         em.persist(card);
         em.persist(card2);
+        em.persist(card3);
         em.persist(cardTag1);
         em.persist(cardTag2);
         em.persist(cardTag3);
+        em.persist(cardTag4);
         em.flush();
     }
     
@@ -157,19 +172,6 @@ class CardTagRepositoryTest {
         }
     }
     
-    @Nested
-    @DisplayName("findAllPackageDtoByTagName 테스트")
-    class findAllPackageDtoByTagName {
-        
-        @Test
-        @DisplayName("응답 테스트")
-        void shouldReturnListPackageDtoTest() {
-            List<PackageDto> packageDtoList = cardTagRepository.findAllPackageDtoByTagName("t1");
-            assertThat(packageDtoList).isNotEmpty();
-            assertThat(packageDtoList.get(0)).extracting("tagName").isEqualTo("t1");
-            assertThat(packageDtoList.get(0)).extracting("nickname").isEqualTo("hello");
-        }
-    }
     
     @Nested
     @DisplayName("findAllCardTagIdInCardIds 테스트")
@@ -179,7 +181,7 @@ class CardTagRepositoryTest {
         @DisplayName("응답 테스트")
         void shouldReturnCardIds() {
             List<CardTag> all = cardTagRepository.findAll();
-            assertThat(all.size()).isEqualTo(3);
+            assertThat(all.size()).isEqualTo(4);
             List<Long> ids = cardTagRepository.findAllCardTagIdInCardIds(
                     new ArrayList<>(Arrays.asList(1L)));
             logger.info("ids: {} ", ids);
@@ -188,6 +190,21 @@ class CardTagRepositoryTest {
     
             
         }
+    }
+    
+    @Nested
+    @DisplayName("findAllPublicCardByTagId 테스트")
+    class countByTagIdTest {
+        
+        @Test
+        @DisplayName("응답 테스트")
+        void findAllPublicCardByTagId() {
+            
+            List<Card> cardList = cardTagRepository.findAllPublicCardByTagId(1L);
+            assertThat(cardList.size()).isEqualTo(1);
+            assertThat(cardList.get(0).getIsPublic()).isEqualTo(true);
+        }
+        
     }
     
 }

--- a/src/test/java/com/wnis/linkyway/repository/TagRepositoryTest.java
+++ b/src/test/java/com/wnis/linkyway/repository/TagRepositoryTest.java
@@ -1,6 +1,9 @@
 package com.wnis.linkyway.repository;
 
 import com.wnis.linkyway.dto.tag.TagResponse;
+import com.wnis.linkyway.entity.Tag;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.CsvFileSource;
 import org.slf4j.Logger;
@@ -8,9 +11,12 @@ import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
 import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.data.domain.PageRequest;
 import org.springframework.test.context.jdbc.Sql;
 
 import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
 
 @DataJpaTest
 @AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
@@ -36,5 +42,16 @@ class TagRepositoryTest {
     void existsByTagNameAndMemberIdTest(String name, Long memberId) {
         boolean bool = tagRepository.existsByMemberIdAndTagName(name, memberId);
         logger.info("result: {}", bool);
+    }
+    
+    @Test
+    @DisplayName("findAllDistinctTagList 테스트")
+    void findAllDistinctTagListTest() {
+        List<Tag> spring = tagRepository.findAllDistinctTagListLikeTagName("spring", PageRequest.of(0, 2));
+        assertThat(spring.size()).isEqualTo(2);
+        for (Tag tag : spring) {
+            logger.info("id: {}, name: {}", tag.getId(), tag.getName());
+            
+        }
     }
 }

--- a/src/test/java/com/wnis/linkyway/service/PackageServiceTest.java
+++ b/src/test/java/com/wnis/linkyway/service/PackageServiceTest.java
@@ -1,6 +1,7 @@
 package com.wnis.linkyway.service;
 
 import com.wnis.linkyway.dto.PackageResponse;
+import com.wnis.linkyway.entity.Card;
 import com.wnis.linkyway.repository.CardTagRepository;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -10,8 +11,10 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
 import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
 import org.springframework.context.annotation.Import;
+import org.springframework.data.domain.PageRequest;
 import org.springframework.test.context.jdbc.Sql;
 
+import javax.persistence.EntityManager;
 import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -24,24 +27,36 @@ public class PackageServiceTest {
 
     private Logger logger = LoggerFactory.getLogger(this.getClass());
     
-    @Autowired CardTagRepository cardTagRepository;
-    @Autowired PackageService packageService;
+    @Autowired
+    CardTagRepository cardTagRepository;
+    @Autowired
+    PackageService packageService;
+    
+    @Autowired
+    EntityManager em;
     
     @Test
     @DisplayName("findAllPackageByTagNameTest")
     void findAllPackageByTagNameTest() {
-    
-        List<PackageResponse> java = packageService.findAllPackageByTagName("java");
+        Card card1 = em.find(Card.class, 1L);
+        card1.updateIsPublic(true);
+        em.flush();
+        
+        List<PackageResponse> java = packageService.findAllPackageByTagName("java",false, PageRequest.of(0, 200));
         java.forEach(packageResponse -> {
             assertThat(packageResponse).extracting("tagName").isEqualTo("java");
         });
+        assertThat(java.size()).isEqualTo(1);
+        assertThat(java.get(0).getNumberOfCard()).isEqualTo(1);
     
-        // 조회시는 대소문자 구분 없이 모두 조회
-        List<PackageResponse> food = packageService.findAllPackageByTagName("food");
-        logger.info("{}", food.get(0).getNumberOfCard());
-        assertThat(food.get(0).getNumberOfCard()).isEqualTo(4);
-        food.forEach(packageResponse -> {
-            assertThat(packageResponse).extracting("tagName").isEqualTo("food");
-        });
+
+//        List<PackageResponse> food = packageService.findAllPackageByTagName("java", PageRequest.of(0, 200));
+//        logger.info("{}", food.get(0).getNumberOfCard());
+//        assertThat(food.get(0).getNumberOfCard()).isEqualTo(1);
+//        food.forEach(packageResponse -> {
+//            assertThat(packageResponse).extracting("tagName").isEqualTo("food");
+//        });
     }
+    
+    
 }


### PR DESCRIPTION
# 특이사항

- API:  ex) api/search/social?isLike=true&tagName="java"&page=0&size=10

- isLike가 true인 경우 Like 검색 그렇지 않은 경우 정확하게 검색
- public 카드를 가진 모든 태그를 조회하기 위해선   api/search/social?isLike=true&페이징~~~
- isLike, tagName은 require= false, tagName을 안쓴 경우 ""이 들어감
- public카드만 검색하도록 수정
- isDeleted = true, 즉 삭제된 카드는 갯수로 세지 않음
- 해당 태그를 가진 카드가 존재하지 않는다면 패키지를 조회하지 않는다