### PR TITLE
Refactor/#196/improve card response

### DIFF
--- a/src/main/java/com/wnis/linkyway/controller/CardController.java
+++ b/src/main/java/com/wnis/linkyway/controller/CardController.java
@@ -11,9 +11,7 @@ import com.wnis.linkyway.security.annotation.CurrentMember;
 import com.wnis.linkyway.service.card.CardService;
 import com.wnis.linkyway.validation.ValidationSequence;
 import io.swagger.annotations.ApiOperation;
-import java.util.List;
 import lombok.RequiredArgsConstructor;
-import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -73,7 +71,7 @@ public class CardController {
     }
 
     @DeleteMapping("/{cardId}")
-    @ApiOperation(value = "카드 완전 삭제", notes = "카드 하나를 휴지통으로 보낸다")
+    @ApiOperation(value = "카드 휴지통으로 보내기", notes = "카드 하나를 휴지통으로 보낸다")
     @Authenticated
     public ResponseEntity<Response<Long>> deleteCard(@PathVariable Long cardId,
         @CurrentMember Long memberId) {

--- a/src/main/java/com/wnis/linkyway/controller/CardController.java
+++ b/src/main/java/com/wnis/linkyway/controller/CardController.java
@@ -102,10 +102,12 @@ public class CardController {
     @Authenticated
     public ResponseEntity<Response<Page<CardResponse>>> findCardsByTagId(
         @RequestParam(value = "lastIdx", required = false) Long lastIdx,
-        @CurrentMember Long memberId, @PathVariable Long tagId) {
+        @CurrentMember Long memberId,
+        Pageable pageable,
+        @PathVariable Long tagId) {
 
         Page<CardResponse> cardResponses = cardService.findCardsByTagId(lastIdx, memberId, tagId,
-            PageRequest.of(0, 200));
+            pageable);
         return ResponseEntity.ok()
             .body(Response.of(HttpStatus.OK, cardResponses, "태그 조회 성공"));
     }

--- a/src/main/java/com/wnis/linkyway/controller/CardController.java
+++ b/src/main/java/com/wnis/linkyway/controller/CardController.java
@@ -1,5 +1,6 @@
 package com.wnis.linkyway.controller;
 
+import com.wnis.linkyway.dto.Page;
 import com.wnis.linkyway.dto.Response;
 import com.wnis.linkyway.dto.card.io.AddCardResponse;
 import com.wnis.linkyway.dto.card.io.CardRequest;
@@ -37,135 +38,107 @@ public class CardController {
     @PostMapping
     @ApiOperation(value = "카드 생성", notes = "카드 요청 정보를 입력 받아 카드 하나를 생성한다")
     @Authenticated
-    public ResponseEntity<Response> addCard(@CurrentMember Long memberId,
+    public ResponseEntity<Response<AddCardResponse>> addCard(@CurrentMember Long memberId,
         @Validated(ValidationSequence.class) @RequestBody CardRequest cardRequest) {
 
         AddCardResponse addCardResponse = cardService.addCard(memberId, cardRequest);
 
         return ResponseEntity.ok()
-            .body(Response.builder()
-                .code(HttpStatus.CREATED.value())
-                .data(addCardResponse)
-                .message("카드가 생성 완료")
-                .build());
+            .body(Response.of(HttpStatus.OK, addCardResponse, "카드가 생성 완료"));
     }
 
     @GetMapping("/{cardId}")
     @ApiOperation(value = "ID를 통해 카드 조회", notes = "Card ID를 활용해 하나의 카드를 조회한다")
     @Authenticated
-    public ResponseEntity<Response> findCardByCardId(@PathVariable Long cardId,
+    public ResponseEntity<Response<CardResponse>> findCardByCardId(@PathVariable Long cardId,
         @CurrentMember Long memberId) {
 
         CardResponse cardResponse = cardService.findCardByCardId(cardId, memberId);
 
         return ResponseEntity.ok()
-            .body(Response.builder()
-                .code(HttpStatus.OK.value())
-                .data(cardResponse)
-                .message("카드 조회 성공")
-                .build());
+            .body(Response.of(HttpStatus.OK, cardResponse, "카드 조회 성공"));
     }
 
     @PutMapping("/{cardId}")
     @ApiOperation(value = "카드 수정", notes = "카드 수정 정보를 이용해 카드를 수정한다")
     @Authenticated
-    public ResponseEntity<Response> updateCard(@CurrentMember Long memberId,
+    public ResponseEntity<Response<Long>> updateCard(@CurrentMember Long memberId,
         @PathVariable Long cardId,
         @Validated(ValidationSequence.class) @RequestBody CardRequest cardRequest) {
 
         Long updatedCardId = cardService.updateCard(memberId, cardId, cardRequest);
 
         return ResponseEntity.ok()
-            .body(Response.builder()
-                .code(HttpStatus.OK.value())
-                .data(updatedCardId)
-                .message("카드 변경 완료")
-                .build());
+            .body(Response.of(HttpStatus.OK, updatedCardId, "카드 변경 완료"));
     }
 
     @DeleteMapping("/{cardId}")
     @ApiOperation(value = "카드 완전 삭제", notes = "카드 하나를 휴지통으로 보낸다")
     @Authenticated
-    public ResponseEntity<Response> deleteCard(@PathVariable Long cardId,
+    public ResponseEntity<Response<Long>> deleteCard(@PathVariable Long cardId,
         @CurrentMember Long memberId) {
 
         Long response = cardService.deleteCard(cardId, memberId);
 
         return ResponseEntity.ok()
-            .body(Response.builder()
-                .code(HttpStatus.OK.value())
-                .data(response)
-                .message("카드 삭제 완료")
-                .build());
+            .body(Response.of(HttpStatus.OK, response, "카드 삭제 완료"));
     }
 
     @GetMapping("/personal/keyword")
     @ApiOperation(value = "키워드를 통한 카드 조회", notes = "키워드를 활용해 여러 카드를 조회한다")
     @Authenticated
-    public ResponseEntity<Response> searchCardByKeywordPersonalPage(
+    public ResponseEntity<Response<Page<CardResponse>>> searchCardByKeywordPersonalPage(
         @RequestParam(value = "lastIdx", required = false) Long lastIdx,
         @RequestParam(value = "keyword") String keyword,
         @CurrentMember Long memberId, Pageable pageable) {
-        List<CardResponse> cardResponses = cardService.SearchCardByKeywordPersonalPage(lastIdx,
+        Page<CardResponse> cardResponses = cardService.SearchCardByKeywordPersonalPage(lastIdx,
             keyword, memberId, pageable);
         return ResponseEntity.ok()
-            .body(Response.of(HttpStatus.OK, cardResponses, "조회 성공"));
+            .body(Response.of(HttpStatus.OK, cardResponses, "키워드 조회 성공"));
     }
 
     @GetMapping("/tag/{tagId}")
     @ApiOperation(value = "태그아이디를 통해 카드 조회", notes = "TAG ID를 가지고 있는 여러 카드를 조회")
     @Authenticated
-    public ResponseEntity<Response> findCardsByTagId(
+    public ResponseEntity<Response<Page<CardResponse>>> findCardsByTagId(
         @RequestParam(value = "lastIdx", required = false) Long lastIdx,
         @CurrentMember Long memberId, @PathVariable Long tagId) {
 
-        List<CardResponse> cardResponses = cardService.findCardsByTagId(lastIdx, memberId, tagId,
+        Page<CardResponse> cardResponses = cardService.findCardsByTagId(lastIdx, memberId, tagId,
             PageRequest.of(0, 200));
         return ResponseEntity.ok()
-            .body(Response.builder()
-                .code(HttpStatus.OK.value())
-                .message("태그에 해당하는 카드 조회 성공")
-                .data(cardResponses)
-                .build());
+            .body(Response.of(HttpStatus.OK, cardResponses, "태그 조회 성공"));
     }
 
 
     @GetMapping("/folder/{folderId}")
     @ApiOperation(value = "폴더 아이디를 활용한 카드 조회", notes = "폴더 ID에 속해있는 카드들 모두 조회")
     @Authenticated
-    public ResponseEntity<Response> findCardsByFolderId(
+    public ResponseEntity<Response<Page<CardResponse>>> findCardsByFolderId(
         @RequestParam(value = "lastIdx", required = false) Long lastIdx,
         @CurrentMember Long memberId,
         @PathVariable Long folderId,
         @RequestParam boolean findDeep, Pageable pageable) {
 
-        List<CardResponse> cardResponses = cardService.findCardsByFolderId(lastIdx, memberId,
+        Page<CardResponse> cardResponses = cardService.findCardsByFolderId(lastIdx, memberId,
             folderId,
             findDeep, pageable);
         return ResponseEntity.ok()
-            .body(Response.builder()
-                .code(HttpStatus.OK.value())
-                .message("폴더에 해당하는 카드 조회 성공")
-                .data(cardResponses)
-                .build());
+            .body(Response.of(HttpStatus.OK, cardResponses, "폴더에 해당하는 카드 조회 성공"));
     }
 
     @GetMapping("/all")
     @ApiOperation(value = "회원 카드 조회", notes = "회원이 가지고 있는 모든 카드 조회")
     @Authenticated
-    public ResponseEntity<Response> findCardsByMemberId(
+    public ResponseEntity<Response<Page<CardResponse>>> findCardsByMemberId(
         @RequestParam(value = "lastIdx", required = false) Long lastIdx,
         @CurrentMember Long memberId,
         Pageable pageable) {
 
-        List<CardResponse> cardResponses = cardService.findCardsByMemberId(lastIdx, memberId,
+        Page<CardResponse> cardResponses = cardService.findCardsByMemberId(lastIdx, memberId,
             pageable);
         return ResponseEntity.ok()
-            .body(Response.builder()
-                .code(HttpStatus.OK.value())
-                .message("태그에 해당하는 카드 조회 성공")
-                .data(cardResponses)
-                .build());
+            .body(Response.of(HttpStatus.OK, cardResponses, "회원이 가지고 있는 카드 조회 성공"));
     }
 
     @PostMapping("/package/copy")

--- a/src/main/java/com/wnis/linkyway/controller/TrashController.java
+++ b/src/main/java/com/wnis/linkyway/controller/TrashController.java
@@ -1,5 +1,6 @@
 package com.wnis.linkyway.controller;
 
+import com.wnis.linkyway.dto.Page;
 import com.wnis.linkyway.dto.Response;
 import com.wnis.linkyway.dto.card.io.CardResponse;
 import com.wnis.linkyway.security.annotation.Authenticated;
@@ -26,9 +27,9 @@ public class TrashController {
     @Authenticated
     ResponseEntity<Response<List<Long>>> updateCardIsDeletedTrueOrFalse(@RequestBody List<Long> ids, @CurrentMember Long memberId,
             @RequestParam Boolean isDeleted) {
-        List<Long> response = null;
+        List<Long> response;
         
-        if (isDeleted == true) {
+        if (isDeleted) {
             response = trashService.deleteCompletely(ids, memberId);
         } else { //isDeleted == false
             response = trashService.updateDeleteCardFalse(ids, memberId);
@@ -41,9 +42,9 @@ public class TrashController {
     @GetMapping
     @ApiOperation(value = "삭제된 카드 조회", notes = "isDeleted 키가 true인 카드들을 조회한다")
     @Authenticated
-    ResponseEntity<Response<List<CardResponse>>> findAllDeletedCard(@CurrentMember Long memberId,
+    ResponseEntity<Response<Page<CardResponse>>> findAllDeletedCard(@CurrentMember Long memberId,
             @RequestParam(value = "lastCardId", required = false) Long lastCardId, Pageable pageable) {
-        List<CardResponse> response = trashService.findAllDeletedCard(memberId,lastCardId, pageable);
+        Page<CardResponse> response = trashService.findAllDeletedCard(memberId,lastCardId, pageable);
         return ResponseEntity.ok(Response.of(HttpStatus.OK, response, "삭제된 카드 조회 성공"));
     }
 }

--- a/src/main/java/com/wnis/linkyway/dto/Page.java
+++ b/src/main/java/com/wnis/linkyway/dto/Page.java
@@ -3,7 +3,6 @@ package com.wnis.linkyway.dto;
 import java.util.Collections;
 import java.util.List;
 import lombok.AccessLevel;
-import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 
 

--- a/src/main/java/com/wnis/linkyway/dto/Page.java
+++ b/src/main/java/com/wnis/linkyway/dto/Page.java
@@ -1,0 +1,32 @@
+package com.wnis.linkyway.dto;
+
+import java.util.Collections;
+import java.util.List;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+
+@RequiredArgsConstructor(access = AccessLevel.PRIVATE)
+public class Page<T> {
+
+    private final List<T> content;
+    private final Boolean hasNext;
+    private final Long lastIndex;
+
+    public static <T> Page<T> of(List<T> content, boolean hasNext, Long lastIndex) {
+        return new Page<>(content, hasNext, lastIndex);
+    }
+
+    public List<T> getContent() {
+        return Collections.unmodifiableList(this.content);
+    }
+
+    public boolean isHasNext() {
+        return hasNext;
+    }
+
+    public Long getLastIndex() {
+        return lastIndex;
+    }
+}

--- a/src/main/java/com/wnis/linkyway/dto/cardtag/CardTagDto.java
+++ b/src/main/java/com/wnis/linkyway/dto/cardtag/CardTagDto.java
@@ -7,6 +7,7 @@ import lombok.Data;
 @Data
 public class CardTagDto {
 
+    private final Long cardTagId;
     private final Long cardId;
     private final String link;
     private final String title;
@@ -19,8 +20,9 @@ public class CardTagDto {
     private final String tagName;
 
     @Builder
-    public CardTagDto(Long cardId, String link, String title, String content, Boolean isPublic, Long folderId,
+    public CardTagDto(Long cardTagId, Long cardId, String link, String title, String content, Boolean isPublic, Long folderId,
         Boolean isDeleted, Long tagId, String tagName) {
+        this.cardTagId = cardTagId;
         this.cardId = cardId;
         this.link = link;
         this.title = title;

--- a/src/main/java/com/wnis/linkyway/repository/card/CardRepository.java
+++ b/src/main/java/com/wnis/linkyway/repository/card/CardRepository.java
@@ -22,31 +22,31 @@ public interface CardRepository extends JpaRepository<Card, Long> {
     @Deprecated
     @Query("select ct.card from CardTag ct join ct.card join ct.tag where ct.tag.id = :tagId and ct.card.isDeleted = false " +
             "order by ct.card.id desc")
-    public List<Card> findCardsByTagId(@Param(value = "tagId") Long tagId, Pageable pageable);
+    List<Card> findCardsByTagId(@Param(value = "tagId") Long tagId, Pageable pageable);
 
     @Deprecated
     @Query("select distinct c from CardTag ct join ct.card c join ct.tag t "
             + "where t.id = :tagId and c.isPublic = true and c.isDeleted = false " +
             "order by ct.card desc")
-    public List<Card> findIsPublicCardsByTagId(@Param(value = "tagId") Long tagId, Pageable pageable);
+    List<Card> findIsPublicCardsByTagId(@Param(value = "tagId") Long tagId, Pageable pageable);
 
     @Deprecated
     @Query("select c from Card c join c.folder f where f.id = :folderId and c.isDeleted = false " +
             "order by c.id desc")
-    public List<Card> findCardsByFolderId(@Param(value = "folderId") Long folderId, Pageable pageable);
+    List<Card> findCardsByFolderId(@Param(value = "folderId") Long folderId, Pageable pageable);
 
     // 삭제 예정 쿼리
     @Deprecated
     @Query("select c from Card c join c.folder f where f.parent.id = :folderId or f.id = :folderId")
-    public List<Card> findDeepFoldersCardsByFolderId(@Param(value = "folderId") Long folderId);
+    List<Card> findDeepFoldersCardsByFolderId(@Param(value = "folderId") Long folderId);
 
     @Deprecated
     @Query("select c from Card c join c.folder f where f.member.id = :memberId and c.isDeleted = false order by c.id desc")
-    public List<Card> findCardsByMemberId(@Param(value = "memberId") Long memberId, Pageable pageable);
+    List<Card> findCardsByMemberId(@Param(value = "memberId") Long memberId, Pageable pageable);
     
     @Query("select c from Card c join c.folder f join f.member m " +
             "where c.id = :cardId and m.id = :memberId")
-    public Optional<Card> findByCardIdAndMemberId(Long cardId, Long memberId);
+    Optional<Card> findByCardIdAndMemberId(Long cardId, Long memberId);
     
     @Query("select c from Card c " +
             "join c.folder f join f.member m " +
@@ -58,12 +58,12 @@ public interface CardRepository extends JpaRepository<Card, Long> {
     @Query("select c.id from Card c " +
             "where c.isDeleted = true and c.modifiedBy <= :deletedDateAt " +
             "order by c.id desc")
-    public Slice<Long> findAllIdToDeletedCardUsingPage(@Param(value = "deletedDateAt") LocalDateTime deletedDateAt, Pageable pageable);
+    Slice<Long> findAllIdToDeletedCardUsingPage(@Param(value = "deletedDateAt") LocalDateTime deletedDateAt, Pageable pageable);
 
     @Query("select c.id from Card c " +
             "where c.id < :lastId and c.isDeleted = true and c.modifiedBy <= :deletedDateAt " +
             "order by c.id desc")
-    public Slice<Long> findAllIdToDeletedCardUsingCursorPage(@Param(value = "deletedDateAt") LocalDateTime deletedDateAt,Long lastId, Pageable pageable);
+    Slice<Long> findAllIdToDeletedCardUsingCursorPage(@Param(value = "deletedDateAt") LocalDateTime deletedDateAt,Long lastId, Pageable pageable);
     
     // findAll Cursor Paging
     @Query("select c from Card c order by c.id desc")
@@ -79,13 +79,13 @@ public interface CardRepository extends JpaRepository<Card, Long> {
             "join fetch c.folder f join f.member m " +
             "where c.isDeleted = :isDeleted and m.id = :memberId " +
             "order by c.id desc")
-    List<Card> findAllByIsDeletedAndMemberIdUsingPage(boolean isDeleted, Long memberId, Pageable pageable);
+    Slice<Card> findAllByIsDeletedAndMemberIdUsingPage(boolean isDeleted, Long memberId, Pageable pageable);
     
     @Query("select c from Card c " +
             "join fetch c.folder f join f.member m " +
             "where c.id < :lastId and c.isDeleted = :isDeleted and m.id = :memberId " +
             "order by c.id desc")
-    List<Card> findAllByIsDeletedAndMemberIdUsingCursorPage(boolean isDeleted, Long lastId, Long memberId, Pageable pageable);
+    Slice<Card> findAllByIsDeletedAndMemberIdUsingCursorPage(boolean isDeleted, Long lastId, Long memberId, Pageable pageable);
     
     @Query("select c from Card c " +
             "join c.folder f " +

--- a/src/main/java/com/wnis/linkyway/repository/card/CardRepositoryCustom.java
+++ b/src/main/java/com/wnis/linkyway/repository/card/CardRepositoryCustom.java
@@ -79,6 +79,11 @@ public class CardRepositoryCustom {
         if (hasNext) {
             cardDtoList.remove(cardDtoList.size() - 1);
         }
+
+        if (cardDtoList.isEmpty()) {
+            return Page.of(cardDtoList, hasNext, null);
+        }
+
         Long returnLastIdx = cardDtoList.get(cardDtoList.size() - 1).getId();
         return Page.of(cardDtoList, hasNext, returnLastIdx);
     }

--- a/src/main/java/com/wnis/linkyway/repository/card/CardRepositoryCustom.java
+++ b/src/main/java/com/wnis/linkyway/repository/card/CardRepositoryCustom.java
@@ -4,6 +4,7 @@ package com.wnis.linkyway.repository.card;
 import com.querydsl.core.types.Projections;
 import com.querydsl.core.types.dsl.BooleanExpression;
 import com.querydsl.jpa.impl.JPAQueryFactory;
+import com.wnis.linkyway.dto.Page;
 import com.wnis.linkyway.dto.card.CardDto;
 import com.wnis.linkyway.entity.QCard;
 import com.wnis.linkyway.entity.QCardTag;
@@ -20,99 +21,9 @@ public class CardRepositoryCustom {
     private final QCard card = QCard.card;
     private final QCardTag cardTag = QCardTag.cardTag;
 
-    public List<CardDto> findAllCardContainKeyword(Long lastIdx, String keyword, Long memberId,
+    public Page<CardDto> findAllCardByFolderIds(Long lastIdx, List<Long> folderList,
         Pageable pageable) {
-        return jpaQueryFactory.select(Projections.constructor(CardDto.class,
-                card.id,
-                card.link,
-                card.title,
-                card.content,
-                card.isPublic,
-                card.isDeleted,
-                card.folder.id,
-                card.createdBy,
-                card.modifiedBy))
-            .from(card)
-            .orderBy(card.id.desc())
-            .where(card.folder.member.id.eq(memberId)
-                .and(card.title.contains(keyword).or(card.content.contains(keyword)))
-                .and(cursorId(lastIdx))
-                .and(card.isDeleted.eq(false)))
-            .limit(pageable.getPageSize())
-            .fetch();
-    }
-
-    private BooleanExpression cursorId(Long lastIdx) {
-        if (lastIdx == null) {
-            return null;
-        }
-        return card.id.lt(lastIdx);
-    }
-
-
-    public List<CardDto> findAllCardByTadId(Long lastIdx, Long tagId, Pageable pageable) {
-        return jpaQueryFactory.select(Projections.constructor(CardDto.class,
-                card.id,
-                card.link,
-                card.title,
-                card.content,
-                card.isPublic,
-                card.isDeleted,
-                card.folder.id,
-                card.createdBy,
-                card.modifiedBy))
-            .from(cardTag)
-            .orderBy(card.id.desc())
-            .join(cardTag.card, card)
-            .where(cardTag.tag.id.eq(tagId)
-                .and(cursorId(lastIdx))
-                .and(card.isDeleted.eq(false)))
-            .limit(pageable.getPageSize())
-            .fetch();
-    }
-
-    public List<CardDto> findAllCardByMemberId(Long lastIdx, Long memberId, Pageable pageable) {
-        return jpaQueryFactory.select(Projections.constructor(CardDto.class,
-                card.id,
-                card.link,
-                card.title,
-                card.content,
-                card.isPublic,
-                card.isDeleted,
-                card.folder.id,
-                card.createdBy,
-                card.modifiedBy))
-            .from(card)
-            .orderBy(card.id.desc())
-            .where(card.folder.member.id.eq(memberId)
-                .and(cursorId(lastIdx))
-                .and(card.isDeleted.eq(false)))
-            .limit(pageable.getPageSize())
-            .fetch();
-    }
-
-    public List<CardDto> findAllCardByFolderId(Long lastIdx, Long folderId, Pageable pageable) {
-        return jpaQueryFactory.select(Projections.constructor(CardDto.class,
-                card.id,
-                card.link,
-                card.title,
-                card.content,
-                card.isPublic,
-                card.isDeleted,
-                card.folder.id,
-                card.createdBy,
-                card.modifiedBy))
-            .from(card)
-            .orderBy(card.id.desc())
-            .where(card.folder.id.eq(folderId).and(cursorId(lastIdx))
-                .and(card.isDeleted.eq(false)))
-            .limit(pageable.getPageSize())
-            .fetch();
-    }
-
-    public List<CardDto> findAllCardByFolderIds(Long lastIdx, List<Long> folderList,
-        Pageable pageable) {
-        return jpaQueryFactory.select(Projections.constructor(CardDto.class,
+        List<CardDto> cardDtoList = jpaQueryFactory.select(Projections.constructor(CardDto.class,
                 card.id,
                 card.link,
                 card.title,
@@ -128,5 +39,113 @@ public class CardRepositoryCustom {
                 .and(card.isDeleted.eq(false)))
             .limit(pageable.getPageSize())
             .fetch();
+
+        return makePage(cardDtoList, pageable);
+    }
+
+    public Page<CardDto> findAllCardContainKeyword(Long lastIdx, String keyword, Long memberId,
+        Pageable pageable) {
+        List<CardDto> cardDtoList = jpaQueryFactory.select(Projections.constructor(CardDto.class,
+                card.id,
+                card.link,
+                card.title,
+                card.content,
+                card.isPublic,
+                card.isDeleted,
+                card.folder.id,
+                card.createdBy,
+                card.modifiedBy))
+            .from(card)
+            .orderBy(card.id.desc())
+            .where(card.folder.member.id.eq(memberId)
+                .and(card.title.contains(keyword).or(card.content.contains(keyword)))
+                .and(cursorId(lastIdx))
+                .and(card.isDeleted.eq(false)))
+            .limit(pageable.getPageSize() + 1)
+            .fetch();
+
+        return makePage(cardDtoList, pageable);
+    }
+
+    private BooleanExpression cursorId(Long lastIdx) {
+        if (lastIdx == null) {
+            return null;
+        }
+        return card.id.lt(lastIdx);
+    }
+
+    private Page<CardDto> makePage(List<CardDto> cardDtoList, Pageable pageable) {
+        boolean hasNext = cardDtoList.size() > pageable.getPageSize();
+        if (hasNext) {
+            cardDtoList.remove(cardDtoList.size() - 1);
+        }
+        Long returnLastIdx = cardDtoList.get(cardDtoList.size() - 1).getId();
+        return Page.of(cardDtoList, hasNext, returnLastIdx);
+    }
+
+    public Page<CardDto> findAllCardByTadId(Long lastIdx, Long tagId, Pageable pageable) {
+        List<CardDto> cardDtoList = jpaQueryFactory.select(Projections.constructor(CardDto.class,
+                card.id,
+                card.link,
+                card.title,
+                card.content,
+                card.isPublic,
+                card.isDeleted,
+                card.folder.id,
+                card.createdBy,
+                card.modifiedBy))
+            .from(cardTag)
+            .orderBy(card.id.desc())
+            .join(cardTag.card, card)
+            .where(cardTag.tag.id.eq(tagId)
+                .and(cursorId(lastIdx))
+                .and(card.isDeleted.eq(false)))
+            .limit(pageable.getPageSize() + 1)
+            .fetch();
+
+        return makePage(cardDtoList, pageable);
+    }
+
+    public Page<CardDto> findAllCardByMemberId(Long lastIdx, Long memberId, Pageable pageable) {
+        List<CardDto> cardDtoList = jpaQueryFactory.select(Projections.constructor(CardDto.class,
+                card.id,
+                card.link,
+                card.title,
+                card.content,
+                card.isPublic,
+                card.isDeleted,
+                card.folder.id,
+                card.createdBy,
+                card.modifiedBy))
+            .from(card)
+            .orderBy(card.id.desc())
+            .where(card.folder.member.id.eq(memberId)
+                .and(cursorId(lastIdx))
+                .and(card.isDeleted.eq(false)))
+            .limit(pageable.getPageSize() + 1)
+            .fetch();
+
+        return makePage(cardDtoList, pageable);
+    }
+
+    public Page<CardDto> findAllCardByFolderId(Long lastIdx, Long folderId, Pageable pageable) {
+        List<CardDto> cardDtoList = jpaQueryFactory.select(Projections.constructor(CardDto.class,
+                card.id,
+                card.link,
+                card.title,
+                card.content,
+                card.isPublic,
+                card.isDeleted,
+                card.folder.id,
+                card.createdBy,
+                card.modifiedBy))
+            .from(card)
+            .orderBy(card.id.desc())
+            .where(card.folder.id.eq(folderId).and(cursorId(lastIdx))
+                .and(card.isDeleted.eq(false)))
+            .limit(pageable.getPageSize() + 1)
+            .fetch();
+
+        return makePage(cardDtoList, pageable);
     }
 }

--- a/src/main/java/com/wnis/linkyway/repository/cardtag/CardTagRepositoryCustom.java
+++ b/src/main/java/com/wnis/linkyway/repository/cardtag/CardTagRepositoryCustom.java
@@ -27,6 +27,7 @@ public class CardTagRepositoryCustom {
     public List<CardTagDto> findCardTagByCardId(Collection<Long> ids) {
         return jpaQueryFactory.select(
                 Projections.constructor(CardTagDto.class,
+                    cardTag.id,
                     card.id,
                     card.link,
                     card.title,
@@ -47,6 +48,7 @@ public class CardTagRepositoryCustom {
     public List<CardTagDto> findCardTagByCard(Collection<Card> cards) {
         return jpaQueryFactory.select(
                 Projections.constructor(CardTagDto.class,
+                    cardTag.id,
                     card.id,
                     card.link,
                     card.title,

--- a/src/main/java/com/wnis/linkyway/service/TrashService.java
+++ b/src/main/java/com/wnis/linkyway/service/TrashService.java
@@ -4,10 +4,15 @@ import com.wnis.linkyway.dto.Page;
 import com.wnis.linkyway.dto.card.io.CardResponse;
 import com.wnis.linkyway.dto.tag.TagResponse;
 import com.wnis.linkyway.entity.Card;
+import com.wnis.linkyway.exception.common.InvalidValueException;
 import com.wnis.linkyway.exception.common.NotFoundEntityException;
+import com.wnis.linkyway.exception.common.ResourceNotFoundException;
+import com.wnis.linkyway.repository.MemberRepository;
 import com.wnis.linkyway.repository.card.CardRepository;
 import com.wnis.linkyway.repository.cardtag.CardTagRepository;
-import com.wnis.linkyway.repository.MemberRepository;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
@@ -15,97 +20,91 @@ import org.springframework.data.domain.Slice;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
-import java.util.ArrayList;
-import java.util.List;
-import java.util.stream.Collectors;
-
 @Service
 @RequiredArgsConstructor
 @Transactional
 public class TrashService {
-    
+
     private final CardRepository cardRepository;
     private final CardTagRepository cardTagRepository;
     private final MemberRepository memberRepository;
-    
+
     public List<Long> updateDeleteCardFalse(List<Long> ids, Long memberId) {
-        if (ids == null) {
-            ids = new ArrayList<>();
+        if (ids.isEmpty()) {
+            throw new InvalidValueException("복원할 카드 id가 비어있습니다. 다시 입력해주세요");
         }
-        if (!memberRepository.existsById(memberId)) {
-            throw new NotFoundEntityException("회원이 존재하지 않습니다");
-        }
-        
-        List<Long> result = new ArrayList<>();
-        
+
         // 회원이 가지고 있는 편집할 id 목록 조회해서 업데이트 복원
-        List<Card> cardList = cardRepository.findAllInIdsAndMemberId(ids, memberId);
-        for (Card card : cardList) {
-            card.updateIsDeleted(false);
-            result.add(card.getId());
+        List<Card> cardList = cardRepository.findAllInIdsAndMemberId(ids, memberId)
+            .stream().filter(Card::getIsDeleted).peek(card -> card.updateIsDeleted(false))
+            .collect(Collectors.toList());
+
+        if (cardList.isEmpty()) {
+            throw new ResourceNotFoundException("어떤 카드도 복원되지 않았습니다. 삭제 상태의 본인 카드 ID를 입력해주세요");
         }
-        return result;
+
+        return cardList.stream().map(Card::getId).collect(Collectors.toList());
     }
-    
+
     public List<Long> deleteCompletely(List<Long> ids, Long memberId) {
-        if (ids == null) {
-            ids = new ArrayList<>();
+        if (ids.isEmpty()) {
+            throw new InvalidValueException("삭제할 카드 id가 비어있습니다. 다시 입력해주세요");
         }
-        
-        if (!memberRepository.existsById(memberId)) {
-            throw new NotFoundEntityException("회원이 존재하지 않습니다");
-        }
-        
         // card Id 중 본인 것의 cardId만 검증해서 가져옴
         List<Long> cardIds = cardRepository.findAllInIdsAndMemberId(ids, memberId).stream()
-                                           .map(Card::getId).collect(Collectors.toList());
+            .filter(Card::getIsDeleted)
+            .map(Card::getId).collect(Collectors.toList());
 
+        if (cardIds.isEmpty()) {
+            throw new ResourceNotFoundException("어떤 데이터도 삭제되지 않았습니다. 삭제 상태의 본인 카드 ID를 입력해주세요");
+        }
         // 연관 관계 제거
         List<Long> cardTagIds = cardTagRepository.findAllCardTagIdInCardIds(cardIds);
         cardTagRepository.deleteAllCardTagInIds(cardTagIds);
         // 카드 제거
-        cardRepository.deleteAllByIdInBatch(ids);
-        
-        return cardTagIds;
+        cardRepository.deleteAllByIdInBatch(cardIds);
+
+        return cardIds;
     }
-    
-    public Page<CardResponse> findAllDeletedCard(Long memberId, Long lastCardId, Pageable pageable) {
+
+    public Page<CardResponse> findAllDeletedCard(Long memberId, Long lastCardId,
+        Pageable pageable) {
         if (!memberRepository.existsById(memberId)) {
             throw new NotFoundEntityException("회원이 존재하지 않습니다");
         }
         Slice<Card> cardList;
-        
+
         // lastCardId 상태에 따라 최초 페이징이냐 커서페이징이냐 결정
         if (checkInvalidLastCardId(lastCardId)) {
             cardList = cardRepository.findAllByIsDeletedAndMemberIdUsingPage(true,
-                                                                             memberId,
-                                                                             PageRequest.of(0, pageable.getPageSize()));
+                memberId,
+                PageRequest.of(0, pageable.getPageSize()));
         } else {
             cardList = cardRepository.findAllByIsDeletedAndMemberIdUsingCursorPage(true,
-                                                                                   lastCardId,
-                                                                                   memberId,
-                                                                                   PageRequest.of(0, pageable.getPageSize()));
+                lastCardId,
+                memberId,
+                PageRequest.of(0, pageable.getPageSize()));
         }
-        
+
         List<CardResponse> content = new ArrayList<>();
-        
+
         for (Card c : cardList.getContent()) {
             List<TagResponse> tags = cardTagRepository.findAllTagResponseByCardId(c.getId());
             CardResponse cardResponse = CardResponse.builder()
-                    .link(c.getLink())
-                    .folderId(c.getFolder().getId())
-                    .cardId(c.getId())
-                    .isPublic(c.getIsPublic())
-                    .title(c.getTitle())
-                    .content(c.getContent())
-                    .tags(tags)
-                    .build();
+                .link(c.getLink())
+                .folderId(c.getFolder().getId())
+                .cardId(c.getId())
+                .isPublic(c.getIsPublic())
+                .title(c.getTitle())
+                .content(c.getContent())
+                .tags(tags)
+                .build();
             content.add(cardResponse);
         }
-        Long lastIdx = content.get(content.size()-1).getCardId();
+        Long lastIdx = content.isEmpty() ? null : content.get(content.size() - 1).getCardId();
         return Page.of(content, cardList.hasNext(), lastIdx);
     }
-    
+
     private boolean checkInvalidLastCardId(Long lastId) {
         return lastId == null || lastId == 1L;
     }

--- a/src/main/java/com/wnis/linkyway/service/card/CardService.java
+++ b/src/main/java/com/wnis/linkyway/service/card/CardService.java
@@ -1,5 +1,6 @@
 package com.wnis.linkyway.service.card;
 
+import com.wnis.linkyway.dto.Page;
 import com.wnis.linkyway.dto.card.io.AddCardResponse;
 import com.wnis.linkyway.dto.card.io.CardRequest;
 import com.wnis.linkyway.dto.card.io.CardResponse;
@@ -9,24 +10,24 @@ import org.springframework.data.domain.Pageable;
 
 public interface CardService {
 
-    public AddCardResponse addCard(Long memberId, CardRequest cardRequest);
+    AddCardResponse addCard(Long memberId, CardRequest cardRequest);
 
-    public CardResponse findCardByCardId(Long cardId, Long memberId);
+    CardResponse findCardByCardId(Long cardId, Long memberId);
 
-    public Long updateCard(Long memberId, Long cardId, CardRequest cardRequest);
+    Long updateCard(Long memberId, Long cardId, CardRequest cardRequest);
 
-    public Long deleteCard(Long cardId, Long memberId);
+    Long deleteCard(Long cardId, Long memberId);
 
-    public List<CardResponse> SearchCardByKeywordPersonalPage(Long lastIdx, String keyword,
+    Page<CardResponse> SearchCardByKeywordPersonalPage(Long lastIdx, String keyword,
         Long memberId, Pageable pageable);
 
-    public List<CardResponse> findCardsByTagId(Long lastIdx, Long memberId, Long tagId,
+    Page<CardResponse> findCardsByTagId(Long lastIdx, Long memberId, Long tagId,
         Pageable pageable);
 
-    public List<CardResponse> findCardsByFolderId(Long lastIdx, Long memberId, Long folderId, boolean findDeep,
+    Page<CardResponse> findCardsByFolderId(Long lastIdx, Long memberId, Long folderId, boolean findDeep,
         Pageable pageable);
 
-    public List<CardResponse> findCardsByMemberId(Long lastIdx, Long memberId, Pageable pageable);
+    Page<CardResponse> findCardsByMemberId(Long lastIdx, Long memberId, Pageable pageable);
 
-    public int copyCardsInPackage(CopyPackageCardsRequest copyPackageCardsRequest);
+    int copyCardsInPackage(CopyPackageCardsRequest copyPackageCardsRequest);
 }

--- a/src/test/java/com/wnis/linkyway/controller/card/CardControllerTest.java
+++ b/src/test/java/com/wnis/linkyway/controller/card/CardControllerTest.java
@@ -12,6 +12,7 @@ import static org.springframework.test.web.servlet.request.MockMvcRequestBuilder
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
+import com.wnis.linkyway.dto.Page;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashSet;
@@ -217,6 +218,8 @@ public class CardControllerTest {
     class findCards {
 
         private List<CardResponse> cardResponses = new ArrayList<CardResponse>();
+
+        private Page<CardResponse> cardResponsePage;
         private Long cardId = 1000L;
         private Long tagId1 = 1L;
         private Long tagId2 = 2L;
@@ -251,13 +254,15 @@ public class CardControllerTest {
                                                       .folderId(folderId)
                                                       .tags(Arrays.asList(tagResponse1))
                                                       .build());
+
+            cardResponsePage = Page.of(cardResponses, true, 10L);
         }
 
         @Test
         @DisplayName("태그 아이디로 사용자의 카드 목록 조회 성공")
         void findCardsByTagIdSuccess() throws Exception {
             // given
-            lenient().doReturn(cardResponses)
+            lenient().doReturn(cardResponsePage)
                      .when(cardService)
                      .findCardsByTagId(any(), any(), anyLong(), any());
             // when
@@ -279,14 +284,14 @@ public class CardControllerTest {
         @DisplayName("폴더 아이디로 사용자의 카드 목록 조회 성공")
         void findCardsByFolderIdSuccess() throws Exception {
             // given
-            lenient().doReturn(cardResponses)
+            lenient().doReturn(cardResponsePage)
                      .when(cardService)
                      .findCardsByFolderId(any(), anyLong(), anyLong(), any(Boolean.class), any());
             // when
             ResultActions resultActions = mockMvc.perform(get("/api/cards/folder/"
                     + folderId).param("findDeep", String.valueOf(true))
                                .contentType("application/json")
-                               .content(objectMapper.writeValueAsString(cardResponses)));
+                               .content(objectMapper.writeValueAsString(cardResponsePage)));
             // then
             MvcResult mvcResult = resultActions.andExpect(status().isOk())
                                                .andExpect(ResponseBodyMatchers.responseBody() // create
@@ -299,12 +304,12 @@ public class CardControllerTest {
         @DisplayName("사용자의 모든 카드 목록 조회 성공")
         void findCardsByMemberIdSuccess() throws Exception {
             // given
-            lenient().doReturn(cardResponses)
+            lenient().doReturn(cardResponsePage)
                      .when(cardService)
                      .findCardsByMemberId(any(), anyLong(), any());
             // when
             ResultActions resultActions = mockMvc.perform(get("/api/cards/all").contentType("application/json")
-                                                                               .content(objectMapper.writeValueAsString(cardResponses)));
+                                                                               .content(objectMapper.writeValueAsString(cardResponsePage)));
             // then
             MvcResult mvcResult = resultActions.andExpect(status().isOk())
                                                .andExpect(ResponseBodyMatchers.responseBody() // create

--- a/src/test/java/com/wnis/linkyway/controller/trash/TrashIntegrationTest.java
+++ b/src/test/java/com/wnis/linkyway/controller/trash/TrashIntegrationTest.java
@@ -56,7 +56,7 @@ public class TrashIntegrationTest {
     @Test
     @WithMockMember
     void deleteCardTest() throws Exception {
-        List<Long> ids = new ArrayList<>(Arrays.asList(1L, 2L, 3L));
+        List<Long> ids = new ArrayList<>(Arrays.asList(1L, 2L, 6L));
         mockMvc.perform(put("/api/trash?isDeleted=false").contentType(MediaType.APPLICATION_JSON)
                                 .content(objectMapper.writeValueAsString(ids)))
                 .andExpect(status().isOk());

--- a/src/test/java/com/wnis/linkyway/repository/CardRepositoryTest.java
+++ b/src/test/java/com/wnis/linkyway/repository/CardRepositoryTest.java
@@ -264,9 +264,9 @@ public class CardRepositoryTest {
         cardList.get(1).updateIsDeleted(true);
         em.flush();
         
-        List<Card> result = cardRepository.findAllByIsDeletedAndMemberIdUsingPage(true, 1L, PageRequest.of(0, 2));
-        assertThat(result.size()).isEqualTo(2);
-        assertThat(result.get(0)).extracting("id").isEqualTo(6L);
+        Slice<Card> result = cardRepository.findAllByIsDeletedAndMemberIdUsingPage(true, 1L, PageRequest.of(0, 2));
+        assertThat(result.getContent().size()).isEqualTo(2);
+        assertThat(result.getContent().get(0)).extracting("id").isEqualTo(6L);
         
     }
     
@@ -278,9 +278,9 @@ public class CardRepositoryTest {
         cardList.get(1).updateIsDeleted(true);
         em.flush();
     
-        List<Card> result = cardRepository.findAllByIsDeletedAndMemberIdUsingCursorPage(true, 6L,1L, PageRequest.of(0, 2));
-        assertThat(result.size()).isEqualTo(2);
-        assertThat(result.get(0)).extracting("id").isEqualTo(2L);
+        Slice<Card> result = cardRepository.findAllByIsDeletedAndMemberIdUsingCursorPage(true, 6L,1L, PageRequest.of(0, 2));
+        assertThat(result.getContent().size()).isEqualTo(2);
+        assertThat(result.getContent().get(0)).extracting("id").isEqualTo(2L);
 
     }
     

--- a/src/test/java/com/wnis/linkyway/repository/card/CardRepositoryCustomTest.java
+++ b/src/test/java/com/wnis/linkyway/repository/card/CardRepositoryCustomTest.java
@@ -3,6 +3,7 @@ package com.wnis.linkyway.repository.card;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import com.wnis.linkyway.config.QueryDslConfiguration;
+import com.wnis.linkyway.dto.Page;
 import com.wnis.linkyway.dto.card.CardDto;
 import java.util.List;
 import javax.persistence.EntityManager;
@@ -39,18 +40,18 @@ class CardRepositoryCustomTest {
         @Test
         void checkCursorPaging() {
             // first search(lastIndex 가 null인 경우 -> offset으로 동작해야함
-            List<CardDto> list = cardRepositoryCustom.findAllCardContainKeyword(null,
+            Page<CardDto> page = cardRepositoryCustom.findAllCardContainKeyword(null,
                 "", 1L, PageRequest.of(0, 2));
-            assertThat(list.size()).isEqualTo(2);
-            assertThat(list).extracting("id")
+            assertThat(page.getContent().size()).isEqualTo(2);
+            assertThat(page.getContent()).extracting("id")
                 .contains(5L, Index.atIndex(0))
                 .contains(4L, Index.atIndex(1));
 
             // second search(lastIndex가 존재하는 경우 -> 커서페이징 탐색
-            List<CardDto> cursorList = cardRepositoryCustom.findAllCardContainKeyword(5L, "", 1L,
+            Page<CardDto> cursorPage = cardRepositoryCustom.findAllCardContainKeyword(5L, "", 1L,
                 PageRequest.of(0, 3));
-            assertThat(cursorList.size()).isEqualTo(3);
-            assertThat(cursorList).extracting("id")
+            assertThat(cursorPage.getContent().size()).isEqualTo(3);
+            assertThat(cursorPage.getContent()).extracting("id")
                 .contains(4L, Index.atIndex(0))
                 .contains(3L, Index.atIndex(1))
                 .contains(2L, Index.atIndex(2));
@@ -58,9 +59,9 @@ class CardRepositoryCustomTest {
 
         @Test
         void checkKeyword() {
-            List<CardDto> list = cardRepositoryCustom.findAllCardContainKeyword(null, "숯불", 1L,
+            Page<CardDto> page = cardRepositoryCustom.findAllCardContainKeyword(null, "숯불", 1L,
                 PageRequest.of(0, 5));
-            list.forEach(cardDto -> {
+            page.getContent().forEach(cardDto -> {
                 boolean hasWord = cardDto.getContent().contains("숯불") ||
                     cardDto.getTitle().contains("숯불");
 
@@ -75,18 +76,18 @@ class CardRepositoryCustomTest {
         @Test
         void checkCursorPaging() {
             // first search(lastIndex 가 null인 경우 -> offset으로 동작해야함
-            List<CardDto> cardDtoList = cardRepositoryCustom.findAllCardByTadId(null, 2L,
+            Page<CardDto> cardDtoPage = cardRepositoryCustom.findAllCardByTadId(null, 2L,
                 PageRequest.of(0, 3));
-            assertThat(cardDtoList.size()).isEqualTo(3);
-            assertThat(cardDtoList).extracting("id").contains(5L, Index.atIndex(0));
+            assertThat(cardDtoPage.getContent().size()).isEqualTo(3);
+            assertThat(cardDtoPage.getContent()).extracting("id").contains(5L, Index.atIndex(0));
 
             // second search(lastIndex가 존재하는 경우 -> 커서페이징 탐색
-            List<CardDto> cardDtoList2 = cardRepositoryCustom.findAllCardByTadId(6L, 2L,
+            Page<CardDto> cardDtoPage2 = cardRepositoryCustom.findAllCardByTadId(6L, 2L,
                 PageRequest.of(0, 3));
 
 //            System.out.println(cardDtoList2);
-            assertThat(cardDtoList2.size()).isEqualTo(3);
-            assertThat(cardDtoList2).extracting("id").contains(5L, Index.atIndex(0));
+            assertThat(cardDtoPage2.getContent().size()).isEqualTo(3);
+            assertThat(cardDtoPage2.getContent()).extracting("id").contains(5L, Index.atIndex(0));
         }
     }
 
@@ -97,10 +98,10 @@ class CardRepositoryCustomTest {
         @Test
         void checkCursorPaging() {
             // first search(lastIndex 가 null인 경우 -> offset으로 동작해야함
-            List<CardDto> cardDtoList = cardRepositoryCustom.findAllCardByMemberId(null, 1L,
+            Page<CardDto> cardDtoPage = cardRepositoryCustom.findAllCardByMemberId(null, 1L,
                 PageRequest.of(0, 5));
-            logger.info("{}", cardDtoList);
-            assertThat(cardDtoList.size()).isEqualTo(5);
+            logger.info("{}", cardDtoPage.getContent());
+            assertThat(cardDtoPage.getContent().size()).isEqualTo(5);
         }
     }
 

--- a/src/test/java/com/wnis/linkyway/repository/card/CardRepositoryCustomTest.java
+++ b/src/test/java/com/wnis/linkyway/repository/card/CardRepositoryCustomTest.java
@@ -5,7 +5,6 @@ import static org.assertj.core.api.Assertions.assertThat;
 import com.wnis.linkyway.config.QueryDslConfiguration;
 import com.wnis.linkyway.dto.Page;
 import com.wnis.linkyway.dto.card.CardDto;
-import java.util.List;
 import javax.persistence.EntityManager;
 import org.assertj.core.data.Index;
 import org.junit.jupiter.api.Nested;
@@ -68,6 +67,16 @@ class CardRepositoryCustomTest {
                 assertThat(hasWord).isEqualTo(true);
             });
         }
+
+        @Test
+        void emptyContentTest() {
+            Page<CardDto> page = cardRepositoryCustom.findAllCardContainKeyword(null,
+                "asdfasqweQ!Qq", 1L, PageRequest.of(0, 5));
+            logger.info("{}", page);
+            assertThat(page.getContent()).isNotNull();
+            assertThat(page.getLastIndex()).isNull();
+            assertThat(page.isHasNext()).isFalse();
+        }
     }
 
     @Nested
@@ -89,6 +98,16 @@ class CardRepositoryCustomTest {
             assertThat(cardDtoPage2.getContent().size()).isEqualTo(3);
             assertThat(cardDtoPage2.getContent()).extracting("id").contains(5L, Index.atIndex(0));
         }
+
+        @Test
+        void emptyContentTest() {
+            Page<CardDto> page = cardRepositoryCustom.findAllCardByTadId(null, 100L,
+                PageRequest.of(0, 5));
+            logger.info("{}", page);
+            assertThat(page.getContent()).isNotNull();
+            assertThat(page.getLastIndex()).isNull();
+            assertThat(page.isHasNext()).isFalse();
+        }
     }
 
 
@@ -102,6 +121,16 @@ class CardRepositoryCustomTest {
                 PageRequest.of(0, 5));
             logger.info("{}", cardDtoPage.getContent());
             assertThat(cardDtoPage.getContent().size()).isEqualTo(5);
+        }
+
+        @Test
+        void emptyContentTest() {
+            Page<CardDto> page = cardRepositoryCustom.findAllCardByMemberId(null, 100L,
+                PageRequest.of(0, 5));
+            logger.info("{}", page);
+            assertThat(page.getContent()).isNotNull();
+            assertThat(page.getLastIndex()).isNull();
+            assertThat(page.isHasNext()).isFalse();
         }
     }
 

--- a/src/test/java/com/wnis/linkyway/service/TrashServiceTest.java
+++ b/src/test/java/com/wnis/linkyway/service/TrashServiceTest.java
@@ -44,26 +44,27 @@ public class TrashServiceTest {
     @DisplayName("카드 복원")
     void shouldChangeCardIsDeletedPropertiesTest() {
         // 내부 속성이 제대로 변했는지 테스트
-        List<Long> ids = new ArrayList<>(Arrays.asList(1L, 2L));
+        List<Long> ids = new ArrayList<>(Arrays.asList(6L));
+        Card before = em.find(Card.class, 6L);
+        assertThat(before.getIsDeleted()).isEqualTo(true);
         trashService.updateDeleteCardFalse(ids, VALID_MEMBER_ID);
         em.flush();
         em.clear();
         
-        Card c1 = em.find(Card.class, 1L);
-        Card c2 = em.find(Card.class, 2L);
+        Card c1 = em.find(Card.class, 6L);
         
         assertThat(c1.getIsDeleted()).isEqualTo(false);
-        assertThat(c2.getIsDeleted()).isEqualTo(false);
+
     }
     
     @Test
     @DisplayName("완전한 카드 삭제")
     void shouldDeleteCardCompletelyInDB() {
-        List<Long> ids = new ArrayList<>(Arrays.asList(1L, 2L, 3L));
+        List<Long> ids = new ArrayList<>(Arrays.asList(1L, 2L, 6L));
         List<Long> deletedIds = trashService.deleteCompletely(ids, 1L);
         List<Long> idList = cardRepository.findAll().stream().map(Card::getId).collect(Collectors.toList());
-        assertThat(idList.size()).isEqualTo(3);
-        assertThat(idList).doesNotContain(1L, 2L, 3L);
+        assertThat(idList.size()).isEqualTo(5);
+        assertThat(idList).doesNotContain(6L);
         em.flush();
         
     }

--- a/src/test/java/com/wnis/linkyway/service/TrashServiceTest.java
+++ b/src/test/java/com/wnis/linkyway/service/TrashServiceTest.java
@@ -1,5 +1,6 @@
 package com.wnis.linkyway.service;
 
+import com.wnis.linkyway.dto.Page;
 import com.wnis.linkyway.dto.card.io.CardResponse;
 import com.wnis.linkyway.entity.Card;
 import com.wnis.linkyway.repository.card.CardRepository;
@@ -71,8 +72,8 @@ public class TrashServiceTest {
     @DisplayName("삭제된 카드 조회")
     void shouldReturnDeletedCardFormatTest() {
         // 제대로 응답 되는지 테스트
-        List<CardResponse> cardResponseList = trashService.findAllDeletedCard(VALID_MEMBER_ID, 7L, PageRequest.of(0, 2));
-        
+        Page<CardResponse> cardResponsePage = trashService.findAllDeletedCard(VALID_MEMBER_ID, 7L, PageRequest.of(0, 2));
+        List<CardResponse> cardResponseList = cardResponsePage.getContent();
         assertThat(cardResponseList.size()).isEqualTo(1);
         assertThat(cardResponseList.get(0).getCardId()).isNotNull();
         assertThat(cardResponseList.get(0).getFolderId()).isNotNull();
@@ -82,4 +83,5 @@ public class TrashServiceTest {
         assertThat(cardResponseList.get(0).getContent()).isNotNull();
         assertThat(cardResponseList.get(0).getTags()).isNotNull();
     }
+
 }

--- a/src/test/java/com/wnis/linkyway/service/card/CardServiceFindTest.java
+++ b/src/test/java/com/wnis/linkyway/service/card/CardServiceFindTest.java
@@ -9,6 +9,7 @@ import static org.mockito.Mockito.lenient;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 
+import com.wnis.linkyway.dto.Page;
 import com.wnis.linkyway.dto.card.CardDto;
 import com.wnis.linkyway.dto.card.io.CardResponse;
 import com.wnis.linkyway.dto.cardtag.CardTagDto;
@@ -72,6 +73,8 @@ public class CardServiceFindTest {
 
     private List<CardDto> cardDtoList;
 
+    private Page<CardDto> cardDtoPage;
+
     @BeforeEach
     void setUp() {
         // given
@@ -104,6 +107,8 @@ public class CardServiceFindTest {
             .isPublic(false)
             .build();
         cardDtoList.add(cardDto);
+
+        cardDtoPage = Page.of(cardDtoList, true, 10L);
     }
 
     @Nested
@@ -118,19 +123,19 @@ public class CardServiceFindTest {
             lenient().doReturn(tag)
                 .when(tagRepository)
                 .findByIdAndMemberId(anyLong(), anyLong());
-            lenient().doReturn(cardDtoList)
+            lenient().doReturn(cardDtoPage)
                 .when(cardRepositoryCustom)
                 .findAllCardByTadId(any(), any(), any());
 
             // when
-            List<CardResponse> cardResponses = cardService.findCardsByTagId(null, member.getId(),
+            Page<CardResponse> page = cardService.findCardsByTagId(null, member.getId(),
                 tag1.getId(), PageRequest.of(0, 200));
-            System.out.println(cardResponses);
+            System.out.println(page);
             // then
-            assertThat(cardResponses).size()
+            assertThat(page.getContent()).size()
                 .isEqualTo(cardDtoList.size());
-            for (int index = 0; index < cardResponses.size(); index++) {
-                CardResponse cardResponse = cardResponses.get(index);
+            for (int index = 0; index < page.getContent().size(); index++) {
+                CardResponse cardResponse = page.getContent().get(index);
                 CardDto card = cardDtoList.get(index);
 
                 assertThat(cardResponse.getCardId()).isEqualTo(card.getId());

--- a/src/test/java/com/wnis/linkyway/service/card/CardServiceLogicTest.java
+++ b/src/test/java/com/wnis/linkyway/service/card/CardServiceLogicTest.java
@@ -3,6 +3,7 @@ package com.wnis.linkyway.service.card;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import com.wnis.linkyway.config.QueryDslConfiguration;
+import com.wnis.linkyway.dto.Page;
 import com.wnis.linkyway.dto.card.io.CardRequest;
 import com.wnis.linkyway.dto.card.io.CardResponse;
 import com.wnis.linkyway.entity.Card;
@@ -88,10 +89,10 @@ public class CardServiceLogicTest {
         em.persist(newCard2);
         em.flush();
 
-        List<CardResponse> cardResponseList = cardService.findCardsByFolderId(null, 1L, 2L, true,
+        Page<CardResponse> cardResponseList = cardService.findCardsByFolderId(null, 1L, 2L, true,
             PageRequest.of(0, 200));
         logger.info("{}", cardResponseList);
-        assertThat(cardResponseList.size()).isEqualTo(4);
+        assertThat(cardResponseList.getContent().size()).isEqualTo(4);
     }
 
     @Nested

--- a/src/test/java/com/wnis/linkyway/service/card/CardServiceTest.java
+++ b/src/test/java/com/wnis/linkyway/service/card/CardServiceTest.java
@@ -15,6 +15,7 @@ import com.wnis.linkyway.dto.card.io.CardRequest;
 import com.wnis.linkyway.dto.card.io.CardResponse;
 import com.wnis.linkyway.dto.card.io.CopyCardsRequest;
 import com.wnis.linkyway.dto.card.io.CopyPackageCardsRequest;
+import com.wnis.linkyway.dto.cardtag.CardTagDto;
 import com.wnis.linkyway.dto.tag.TagResponse;
 import com.wnis.linkyway.entity.Card;
 import com.wnis.linkyway.entity.CardTag;
@@ -28,6 +29,8 @@ import com.wnis.linkyway.repository.cardtag.CardTagRepository;
 import com.wnis.linkyway.repository.FolderRepository;
 import com.wnis.linkyway.repository.MemberRepository;
 import com.wnis.linkyway.repository.TagRepository;
+import com.wnis.linkyway.repository.cardtag.CardTagRepositoryCustom;
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashSet;
 import java.util.List;
@@ -64,6 +67,9 @@ public class CardServiceTest {
 
     @Mock
     private CardTagRepository cardTagRepository;
+
+    @Mock
+    private CardTagRepositoryCustom cardTagRepositoryCustom;
 
     private final Long cardId = 1001L;
     private final String link = "https://github.com/DHKH-null29/linky_way_back/issues/12";
@@ -246,8 +252,7 @@ public class CardServiceTest {
                                 .findAllTagResponseByCardId(anyLong());
 
             doReturn(Arrays.asList(tag1)).when(tagRepository).findAllById(any());
-            doReturn(savedCardTagList).when(cardTagRepository).findAllCardTagIdInTagSet(any());
-            doNothing().when(cardTagRepository).deleteAllById(any());
+            doReturn(new ArrayList<CardTagDto>()).when(cardTagRepositoryCustom).findCardTagByCardId(any());
 
             
             // when
@@ -256,9 +261,7 @@ public class CardServiceTest {
             // verify
             verify(cardRepository).findByCardIdAndMemberId(any(), any());
             verify(folderRepository).findByIdAndMemberId(anyLong(), anyLong());
-            verify(cardTagRepository).findAllTagResponseByCardId(anyLong());
             verify(tagRepository).findAllById(any());
-            verify(cardTagRepository).deleteAllById(any());
         }
     }
     


### PR DESCRIPTION
# 변경 사항

- 응답 형태 개선

기존 응답에는 다음 쿼리를 해야 하는지 여부가 없어서 프론트 입장에서 활용하기 힘들었다.  그래서 리턴값에 hasNext, lastIndex를 통해 프론트 입장에서 쉽게 활용할 수 있도록 객체를 설계했다.

```java
@RequiredArgsConstructor(access = AccessLevel.PRIVATE)
public class Page<T> {

    private final List<T> content;
    private final Boolean hasNext;
    private final Long lastIndex;

    public static <T> Page<T> of(List<T> content, boolean hasNext, Long lastIndex) {
        return new Page<>(content, hasNext, lastIndex);
    }

    public List<T> getContent() {
        return Collections.unmodifiableList(this.content);
    }

    public boolean isHasNext() {
        return hasNext;
    }

    public Long getLastIndex() {
        return lastIndex;
    }
}
```

3개의 프로퍼티를 가지는데 content, hasNext, lastIndex를 가진다. 일급 컬렉션을 이용한 이유는 처음엔 Slice를 이용하려 헀는데 불필요한 프로퍼티 정보가 많음.
Slice의 경우 Pageable이라는 객체를 프로퍼티로 제공하는데 우리 서비스의 응답보다 너무 많은 정보를 포함하고 있어서 응답으로 쓰기엔 비효율적으로 판단함.
그리고 List 컬렉션에 원하는 정보 포함 외에 읽기 전용으로만 쓰고 싶어서 불변하게 설계함.